### PR TITLE
Feat: mate api

### DIFF
--- a/src/main/java/com/github/backend/repository/MateRepository.java
+++ b/src/main/java/com/github/backend/repository/MateRepository.java
@@ -1,0 +1,14 @@
+package com.github.backend.repository;
+
+import com.github.backend.web.entity.MateEntity;
+import com.github.backend.web.entity.enums.MateStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MateRepository extends JpaRepository<MateEntity,Long> {
+
+    List<MateEntity> findAllByMateStatus(MateStatus mateStatus);
+}

--- a/src/main/java/com/github/backend/repository/ServiceApplyRepository.java
+++ b/src/main/java/com/github/backend/repository/ServiceApplyRepository.java
@@ -1,12 +1,19 @@
 package com.github.backend.repository;
 
 import com.github.backend.web.entity.CareEntity;
+import com.github.backend.web.entity.MateEntity;
 import com.github.backend.web.entity.UserEntity;
+import com.github.backend.web.entity.enums.CareStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 
 @Repository
 public interface ServiceApplyRepository extends JpaRepository<CareEntity, Long > {
-    
+
+    List<CareEntity> findAllByMateAndCareStatus(MateEntity mate, CareStatus status);
+
+    List<CareEntity> findAllByCareStatus(CareStatus careStatus);
 }

--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -1,0 +1,56 @@
+package com.github.backend.service;
+
+import com.github.backend.repository.CareRepository;
+import com.github.backend.repository.MateRepository;
+import com.github.backend.service.mapper.MateCaringMapper;
+import com.github.backend.web.dto.AppliedCaringDto;
+import com.github.backend.web.dto.CommonResponseDto;
+import com.github.backend.web.entity.CareEntity;
+import com.github.backend.web.entity.MateEntity;
+import com.github.backend.web.entity.enums.CareStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MateService {
+
+    private final CareRepository careRepository;
+    private final MateRepository mateRepository;
+
+    public CommonResponseDto applyCaring(Long careId) {
+        CareEntity care = careRepository.findById(careId).orElseThrow();
+        MateEntity mate = mateRepository.findById(mateId).orElseThrow();
+        // 만약 동일한 날짜 같은 시간대에 이미 신청한 도움이 있다면 신청불가능하게끔하기
+        care.setMate(mate);
+        care.setCareStatus(CareStatus.IN_PROGRESS);
+        careRepository.save(care);
+        return CommonResponseDto.builder().code(200).success(true).message("도움 지원이 완료되었습니다!").build();
+    }
+
+    public List<AppliedCaringDto> viewApplyList(String careStatus) {
+//        try {
+            MateEntity mate = mateRepository.findById(mateId).orElseThrow();
+            CareStatus status = CareStatus.valueOf(careStatus);
+            List<CareEntity> careList = careRepository.findAllByMateAndCareStatus(mate, status);
+            return careList.stream().map(MateCaringMapper.INSTANCE::CareEntityToDTO).toList();
+//        } catch (IllegalArgumentException iae) {
+//            // 존재하지 않는 상태입니다.
+//            return throw new RuntimeException();
+//        }
+    }
+
+    public CommonResponseDto finishCaring(Long careCid) {
+        CareEntity care = careRepository.findById(careCid).orElseThrow();
+        care.setCareStatus(CareStatus.HELP_DONE);
+        careRepository.save(care);
+        return CommonResponseDto.builder().code(200).success(true).message("도움이 완료되었습니다!").build();
+    }
+
+    public List<AppliedCaringDto> viewAllApplyList() {
+        List<CareEntity> careList = careRepository.findAllByCareStatus(CareStatus.WAITING);
+        return careList.stream().map(MateCaringMapper.INSTANCE::CareEntityToDTO).toList();
+    }
+}

--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -1,12 +1,13 @@
 package com.github.backend.service;
 
-import com.github.backend.repository.CareRepository;
 import com.github.backend.repository.MateRepository;
+import com.github.backend.repository.ServiceApplyRepository;
 import com.github.backend.service.mapper.MateCaringMapper;
 import com.github.backend.web.dto.AppliedCaringDto;
 import com.github.backend.web.dto.CommonResponseDto;
 import com.github.backend.web.entity.CareEntity;
 import com.github.backend.web.entity.MateEntity;
+import com.github.backend.web.entity.custom.CustomUserDetails;
 import com.github.backend.web.entity.enums.CareStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,10 +18,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MateService {
 
-    private final CareRepository careRepository;
+    private final ServiceApplyRepository careRepository;
     private final MateRepository mateRepository;
 
-    public CommonResponseDto applyCaring(Long careId) {
+    public CommonResponseDto applyCaring(Long careId, CustomUserDetails customUserDetails) {
+        Long mateId = customUserDetails.getUser().getUserCid();
         CareEntity care = careRepository.findById(careId).orElseThrow();
         MateEntity mate = mateRepository.findById(mateId).orElseThrow();
         // 만약 동일한 날짜 같은 시간대에 이미 신청한 도움이 있다면 신청불가능하게끔하기
@@ -30,9 +32,9 @@ public class MateService {
         return CommonResponseDto.builder().code(200).success(true).message("도움 지원이 완료되었습니다!").build();
     }
 
-    public List<AppliedCaringDto> viewApplyList(String careStatus) {
+    public List<AppliedCaringDto> viewApplyList(String careStatus,CustomUserDetails customUserDetails) {
 //        try {
-            MateEntity mate = mateRepository.findById(mateId).orElseThrow();
+            MateEntity mate = mateRepository.findById(customUserDetails.getUser().getUserCid()).orElseThrow();
             CareStatus status = CareStatus.valueOf(careStatus);
             List<CareEntity> careList = careRepository.findAllByMateAndCareStatus(mate, status);
             return careList.stream().map(MateCaringMapper.INSTANCE::CareEntityToDTO).toList();

--- a/src/main/java/com/github/backend/service/mapper/MateCaringMapper.java
+++ b/src/main/java/com/github/backend/service/mapper/MateCaringMapper.java
@@ -1,0 +1,20 @@
+package com.github.backend.service.mapper;
+
+import com.github.backend.web.dto.AppliedCaringDto;
+import com.github.backend.web.entity.CareEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface MateCaringMapper {
+        MateCaringMapper INSTANCE = Mappers.getMapper(MateCaringMapper.class);
+        @Mapping(target="departureLoc",source="departureloc")
+        @Mapping(target="arrivalLoc",source="arrivalloc")
+        @Mapping(target="cost",source="cost")
+        @Mapping(target="careDateTime",source="careDateTime")
+        @Mapping(target="userNickname",source="user.nickname")
+        AppliedCaringDto CareEntityToDTO(CareEntity careEntity);
+
+    }
+

--- a/src/main/java/com/github/backend/service/mapper/MateCaringMapper.java
+++ b/src/main/java/com/github/backend/service/mapper/MateCaringMapper.java
@@ -9,11 +9,15 @@ import org.mapstruct.factory.Mappers;
 @Mapper
 public interface MateCaringMapper {
         MateCaringMapper INSTANCE = Mappers.getMapper(MateCaringMapper.class);
-        @Mapping(target="departureLoc",source="departureloc")
-        @Mapping(target="arrivalLoc",source="arrivalloc")
+        @Mapping(target="careCid",source="careCid")
+        @Mapping(target="userId",source="user.userId")
+        @Mapping(target="arrivalLoc",source="arrivalLoc")
         @Mapping(target="cost",source="cost")
-        @Mapping(target="careDateTime",source="careDateTime")
-        @Mapping(target="userNickname",source="user.nickname")
+        @Mapping(target="date",source="careDate")
+        @Mapping(target="startTime",source="careDateTime")
+        @Mapping(target="finishTime",source="requiredTime")
+//        @Mapping(target="content",source="content") // careEntity에 content관련 필드 생성 시 주석 해제
+        @Mapping(target="gender",source="gender")
         AppliedCaringDto CareEntityToDTO(CareEntity careEntity);
 
     }

--- a/src/main/java/com/github/backend/web/controller/MateController.java
+++ b/src/main/java/com/github/backend/web/controller/MateController.java
@@ -3,11 +3,13 @@ package com.github.backend.web.controller;
 import com.github.backend.service.MateService;
 import com.github.backend.web.dto.AppliedCaringDto;
 import com.github.backend.web.dto.CommonResponseDto;
+import com.github.backend.web.entity.custom.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,20 +23,21 @@ public class MateController {
 
     private final MateService mateService;
 
-//    @Operation(summary = "메이트 인증 대기 화면", description = "메이트로 회원가입 신청하고 대기중인 회원의 화면")
     @Operation(summary = "도움 지원하기", description = "진행중인 도움 모집건에 지원한다.")
     @PostMapping("")
-    public CommonResponseDto applyCaring(@PathVariable Long careId){
+    public CommonResponseDto applyCaring(@PathVariable Long careId,
+                                         @AuthenticationPrincipal CustomUserDetails customUserDetails){
         log.info("[GET] 메이트 로그인 후 메인화면 조회 요청 들어왔습니다");
-        return mateService.applyCaring(careId);
+        return mateService.applyCaring(careId,customUserDetails);
     }
 
     @Operation(summary = "지원한 도움 목록 조회", description = "지원한 도움 목록을 조회한다/진행중/완료")
     @GetMapping("/applyCarelist")
     public ResponseEntity<List<AppliedCaringDto>> viewApplyList(
-            @RequestParam String careStatus
+            @RequestParam String careStatus,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
-        List<AppliedCaringDto> applyCaringList = mateService.viewApplyList(careStatus);
+        List<AppliedCaringDto> applyCaringList = mateService.viewApplyList(careStatus,customUserDetails);
         return ResponseEntity.ok().body(applyCaringList);
     }
 
@@ -48,20 +51,19 @@ public class MateController {
 
 
 
-    @Operation(summary = "도움 완료하기", description = "도움을 끝내고 정산까지 됐을 시 도움을 완료한다")
+    @Operation(summary = "도움 완료하기", description = "도움을 끝내고 도움 완료한다")
     @PutMapping("/finish/{careCid}")
     public CommonResponseDto finishCaring(@PathVariable Long careCid){
         return mateService.finishCaring(careCid);
-
     }
 
-
-    @Operation(summary = "도움 취소하기", description = "지원한 도움을 취소한다")
-    @PutMapping("/cancel/{careCid}")
-    public CommonResponseDto cancelCaring(@RequestParam Long careCid){
-        return mateService.cancelCaring(careCid);
-
-    }
+//
+//    @Operation(summary = "도움 취소하기", description = "지원한 도움을 취소한다")
+//    @PutMapping("/cancel/{careCid}")
+//    public CommonResponseDto cancelCaring(@RequestParam Long careCid){
+//        return mateService.cancelCaring(careCid);
+//
+//    } 메이트가 도움 취소한 내역을 따로 관리할 수 있는 테이블 생성되면 주석 해제
 
 
 

--- a/src/main/java/com/github/backend/web/controller/MateController.java
+++ b/src/main/java/com/github/backend/web/controller/MateController.java
@@ -1,0 +1,68 @@
+package com.github.backend.web.controller;
+
+import com.github.backend.service.MateService;
+import com.github.backend.web.dto.AppliedCaringDto;
+import com.github.backend.web.dto.CommonResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mate")
+@Slf4j
+@Tag(name="메이트 API",description = "메이트의 도움 신청, 도움 조회")
+public class MateController {
+
+    private final MateService mateService;
+
+//    @Operation(summary = "메이트 인증 대기 화면", description = "메이트로 회원가입 신청하고 대기중인 회원의 화면")
+    @Operation(summary = "도움 지원하기", description = "진행중인 도움 모집건에 지원한다.")
+    @PostMapping("")
+    public CommonResponseDto applyCaring(@PathVariable Long careId){
+        log.info("[GET] 메이트 로그인 후 메인화면 조회 요청 들어왔습니다");
+        return mateService.applyCaring(careId);
+    }
+
+    @Operation(summary = "지원한 도움 목록 조회", description = "지원한 도움 목록을 조회한다/진행중/완료")
+    @GetMapping("/applyCarelist")
+    public ResponseEntity<List<AppliedCaringDto>> viewApplyList(
+            @RequestParam String careStatus
+    ){
+        List<AppliedCaringDto> applyCaringList = mateService.viewApplyList(careStatus);
+        return ResponseEntity.ok().body(applyCaringList);
+    }
+
+
+    @Operation(summary = "전체 도움 목록 조회", description = "현재 대기중인 전체 도움 목록을 조회한다")
+    @GetMapping("/all-applyCarelist")
+    public ResponseEntity<List<AppliedCaringDto>> viewAllApplyList(){
+        List<AppliedCaringDto> applyCaringList = mateService.viewAllApplyList();
+        return ResponseEntity.ok().body(applyCaringList);
+    }
+
+
+
+    @Operation(summary = "도움 완료하기", description = "도움을 끝내고 정산까지 됐을 시 도움을 완료한다")
+    @PutMapping("/finish/{careCid}")
+    public CommonResponseDto finishCaring(@PathVariable Long careCid){
+        return mateService.finishCaring(careCid);
+
+    }
+
+
+    @Operation(summary = "도움 취소하기", description = "지원한 도움을 취소한다")
+    @PutMapping("/cancel/{careCid}")
+    public CommonResponseDto cancelCaring(@RequestParam Long careCid){
+        return mateService.cancelCaring(careCid);
+
+    }
+
+
+
+}

--- a/src/main/java/com/github/backend/web/dto/AppliedCaringDto.java
+++ b/src/main/java/com/github/backend/web/dto/AppliedCaringDto.java
@@ -1,0 +1,20 @@
+package com.github.backend.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+public class AppliedCaringDto {
+private String userNickname;
+private String departureLoc;
+private String arrivalLoc;
+private Long cost;
+private LocalDateTime careDateTime;
+
+
+}

--- a/src/main/java/com/github/backend/web/dto/AppliedCaringDto.java
+++ b/src/main/java/com/github/backend/web/dto/AppliedCaringDto.java
@@ -1,20 +1,25 @@
 package com.github.backend.web.dto;
 
+import com.github.backend.web.entity.enums.Gender;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Getter
 @Setter
 @Builder
 public class AppliedCaringDto {
-private String userNickname;
-private String departureLoc;
+private Long careCid;
+private String userId;
+private LocalDate date;
+private LocalTime startTime;
+private LocalTime finishTime;
 private String arrivalLoc;
 private Long cost;
-private LocalDateTime careDateTime;
-
-
+private String content;
+private Gender gender;
 }


### PR DESCRIPTION
- 메이트의 대기중인 도움서비스 조회하기 및 신청하기 구현
- 메이트가 요청한 도움서비스(status="진행중") 조회하기 구현
- 메이트가 요청하여 완료한 도움서비스(status="완료") 조회하기 구현
- 메이트가 도움 완료한 서비스 완료하기 클릭시 상태(진행중->완료) 변경 구현

* 이외에 주석처리한 코드는 엔티티 미변경(유저의 주민등록번호, 본명 등) 및 새로운 테이블(메이트의 도움히스토리) 생성 미정이라 코드예시만 짜놓고 완성하진않았습니다!
* 로컬에서 문제없이 실행돼서 머지해도 문제는 없을거라 생각합니다 ..........