### PR TITLE
Feat: create mateCareHistory entity

### DIFF
--- a/src/main/java/com/github/backend/repository/MateCareHistoryRepository.java
+++ b/src/main/java/com/github/backend/repository/MateCareHistoryRepository.java
@@ -1,0 +1,17 @@
+package com.github.backend.repository;
+
+import com.github.backend.web.entity.CareEntity;
+import com.github.backend.web.entity.MateCareHistoryEntity;
+import com.github.backend.web.entity.MateEntity;
+import com.github.backend.web.entity.enums.MateCareStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MateCareHistoryRepository extends JpaRepository<MateCareHistoryEntity,Long> {
+    MateCareHistoryEntity findByCareAndMate(CareEntity care, MateEntity mate);
+
+    int countByMateCareStatusAndMate(MateCareStatus mateCareStatus,MateEntity mate);
+
+    List<MateCareHistoryEntity> findAllByMateAndMateCareStatus(MateEntity mate, MateCareStatus mateCareStatus);
+}

--- a/src/main/java/com/github/backend/repository/ServiceApplyRepository.java
+++ b/src/main/java/com/github/backend/repository/ServiceApplyRepository.java
@@ -18,4 +18,6 @@ public interface ServiceApplyRepository extends JpaRepository<CareEntity, Long >
     List<CareEntity> findAllByCareStatus(CareStatus careStatus);
 
     List<CareEntity> findAllByUserAndCareStatus(UserEntity userEntity, CareStatus careStatus);
+
+    Integer countByCareStatus(CareStatus careStatus);
 }

--- a/src/main/java/com/github/backend/service/mapper/MateCaringMapper.java
+++ b/src/main/java/com/github/backend/service/mapper/MateCaringMapper.java
@@ -1,6 +1,6 @@
 package com.github.backend.service.mapper;
 
-import com.github.backend.web.dto.AppliedCaringDto;
+import com.github.backend.web.dto.mates.CaringDto;
 import com.github.backend.web.entity.CareEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -9,16 +9,13 @@ import org.mapstruct.factory.Mappers;
 @Mapper
 public interface MateCaringMapper {
         MateCaringMapper INSTANCE = Mappers.getMapper(MateCaringMapper.class);
-        @Mapping(target="careCid",source="careCid")
-        @Mapping(target="userId",source="user.userId")
+
         @Mapping(target="arrivalLoc",source="arrivalLoc")
-        @Mapping(target="cost",source="cost")
         @Mapping(target="date",source="careDate")
         @Mapping(target="startTime",source="careDateTime")
         @Mapping(target="finishTime",source="requiredTime")
 //        @Mapping(target="content",source="content") // careEntity에 content관련 필드 생성 시 주석 해제
-        @Mapping(target="gender",source="gender")
-        AppliedCaringDto CareEntityToDTO(CareEntity careEntity);
+        CaringDto CareEntityToDTO(CareEntity careEntity);
 
     }
 

--- a/src/main/java/com/github/backend/service/mapper/MateMapper.java
+++ b/src/main/java/com/github/backend/service/mapper/MateMapper.java
@@ -1,6 +1,6 @@
 package com.github.backend.service.mapper;
 
-import com.github.backend.web.dto.MateDto;
+import com.github.backend.web.dto.mates.MateDto;
 import com.github.backend.web.entity.MateEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;

--- a/src/main/java/com/github/backend/web/dto/mates/CaringDetailsDto.java
+++ b/src/main/java/com/github/backend/web/dto/mates/CaringDetailsDto.java
@@ -1,4 +1,4 @@
-package com.github.backend.web.dto;
+package com.github.backend.web.dto.mates;
 
 import com.github.backend.web.entity.enums.Gender;
 import lombok.Builder;
@@ -12,7 +12,7 @@ import java.time.LocalTime;
 @Getter
 @Setter
 @Builder
-public class AppliedCaringDto {
+public class CaringDetailsDto {
 private Long careCid;
 private String userId;
 private LocalDate date;

--- a/src/main/java/com/github/backend/web/dto/mates/CaringDto.java
+++ b/src/main/java/com/github/backend/web/dto/mates/CaringDto.java
@@ -1,0 +1,19 @@
+package com.github.backend.web.dto.mates;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@Builder
+public class CaringDto {
+    private String content;
+    private LocalDate date;
+    private LocalTime startTime;
+    private LocalTime finishTime;
+    private String arrivalLoc;
+}

--- a/src/main/java/com/github/backend/web/dto/mates/MainPageDto.java
+++ b/src/main/java/com/github/backend/web/dto/mates/MainPageDto.java
@@ -1,0 +1,14 @@
+package com.github.backend.web.dto.mates;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class MainPageDto {
+private int waitingCount;
+}

--- a/src/main/java/com/github/backend/web/dto/mates/MateDto.java
+++ b/src/main/java/com/github/backend/web/dto/mates/MateDto.java
@@ -1,4 +1,4 @@
-package com.github.backend.web.dto;
+package com.github.backend.web.dto.mates;
 
 import com.github.backend.web.entity.enums.Gender;
 import lombok.*;
@@ -14,6 +14,6 @@ public class MateDto {
     private String mateId;
     private String email;
     private Gender mateGender;
-    private String mateName;        // 메이트 본명 엔티티에 필드 생기면 주석 해제
-    private String registrationNum; // 주민등록번호 엔티티에 생기면 주석 해제
+    private String mateName;
+    private String registrationNum;
 }

--- a/src/main/java/com/github/backend/web/dto/mates/MyPageDto.java
+++ b/src/main/java/com/github/backend/web/dto/mates/MyPageDto.java
@@ -1,0 +1,19 @@
+package com.github.backend.web.dto.mates;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class MyPageDto {
+
+    private int waitingCount;
+    private int inProgressCount;
+    private int finishCount;
+    private int cancelCount;
+    private double mateRating;
+}

--- a/src/main/java/com/github/backend/web/entity/MateCareHistoryEntity.java
+++ b/src/main/java/com/github/backend/web/entity/MateCareHistoryEntity.java
@@ -1,0 +1,37 @@
+package com.github.backend.web.entity;
+
+
+import com.github.backend.web.entity.enums.CareStatus;
+import com.github.backend.web.entity.enums.MateCareStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Builder
+@AllArgsConstructor
+@Table(name = "mate_care_history_table")
+public class MateCareHistoryEntity {
+    @Id
+    @Column(name="mate_care_history_cid")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "메이트 도움 내역 고유 아이디")
+    private Long mateCareHistoryCid;
+
+    @Column
+    @Schema(description = "메이트의 도움 상태",example = "취소")
+    private MateCareStatus mateCareStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mate_cid", referencedColumnName = "mate_cid")
+    private MateEntity mate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "care_cid", referencedColumnName = "mate_cid")
+    private CareEntity care;
+
+
+}

--- a/src/main/java/com/github/backend/web/entity/enums/MateCareStatus.java
+++ b/src/main/java/com/github/backend/web/entity/enums/MateCareStatus.java
@@ -1,0 +1,13 @@
+package com.github.backend.web.entity.enums;
+
+public enum MateCareStatus {
+    IN_PROGRESS("진행 중"),
+    HELP_DONE("도움 완료"),
+    CANCEL("취소");
+
+    private final String mateCareStatus;
+
+    MateCareStatus(String mateCareStatus) {
+        this.mateCareStatus = mateCareStatus;
+    }
+}


### PR DESCRIPTION
- 메이트의 도움내역 테이블 추가
- 메인페이지,마이페이지,내역전체조회,상세조회를 위해 필요한 dto를 생성하고 기존에 있던 dto명을 변경
- dto변경에따른 mapper 수정
- 도움 테이블의 상태가 변경될때 메이트도움내역테이블의 상태 또한 변경될 수 있도록 로직을 추가
- 신규요청/ 진행중 / 완료 / 취소 상태별로 건수를 계산할 수 있는 로직 추가