### PR TITLE
fix: master Api

### DIFF
--- a/src/main/java/com/github/backend/web/controller/MasterController.java
+++ b/src/main/java/com/github/backend/web/controller/MasterController.java
@@ -1,18 +1,15 @@
 package com.github.backend.web.controller;
 
-import com.github.backend.properties.CoolsmsProperties;
 import com.github.backend.service.MasterService;
-import com.github.backend.service.SendMessageService;
 import com.github.backend.web.dto.CommonResponseDto;
-import com.github.backend.web.dto.MateDto;
+import com.github.backend.web.dto.UnapprovedMateDto;
+import com.github.backend.web.dto.mates.MateDto;
 import com.github.backend.web.dto.RegisteredUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,14 +22,24 @@ import java.util.List;
 public class MasterController {
     private final MasterService masterService;
 
-@Operation(summary = "메이트 인증하기", description = "메이트로 회원가입 신청한 회원을 인증해준다.")
-@PutMapping("")
-public CommonResponseDto registerMate(
-        @RequestParam("mateId") Long mateId,
-        @RequestParam("register") boolean isAccept){
-    log.info("[POST] 메이트 인증완료/거부 요청 들어왔습니다");
-    return masterService.registerMate(mateId,isAccept);
+@Operation(summary = "메이트 승인하기", description = "메이트로 인증요청한 회원을 승인한다.")
+@PutMapping("/approve/{mateCid}")
+public CommonResponseDto approveMate(
+        @PathVariable Long mateCid){
+    log.info("[PUT] 메이트 인증승인 요청 들어왔습니다");
+    return masterService.approveMate(mateCid);
 }
+
+@Operation(summary = "메이트 미승인하기", description = "메이트로 인증요청한 회원을 미승인한다.")
+@PutMapping("/unapproved/{mateCid}")
+public CommonResponseDto unapprovedMate(
+        @PathVariable Long mateCid,
+        UnapprovedMateDto unapprovedMateDto){
+    log.info("[PUT] 메이트 인증 미승인 요청 들어왔습니다");
+    return masterService.unapprovedMate(mateCid,unapprovedMateDto);
+    }
+
+
 
 
 @Operation(summary = "메이트 신청목록 확인", description = "메이트로 회원가입 신청한 회원 목록을 조회한다")
@@ -57,7 +64,7 @@ public ResponseEntity<MateDto> viewMate(@PathVariable Long mateCid){
 @PutMapping("/mate")
 public CommonResponseDto blackingMate(@RequestParam boolean isBlacklisted,
                                       @RequestParam Long mateCid){
-    return masterService.blackingMate(isBlacklisted,mateCid);
+    return masterService.blacklistingMate(isBlacklisted,mateCid);
 }
 
 
@@ -86,6 +93,6 @@ public ResponseEntity<RegisteredUser> viewUser(@PathVariable Long userCid){
 @PutMapping("/user")
 public CommonResponseDto blackingUser(@RequestParam boolean isBlacklisted,
                                       @RequestParam Long userCid){
-    return masterService.blackingUser(isBlacklisted,userCid);
+    return masterService.blacklistingUser(isBlacklisted,userCid);
 }
 }

--- a/src/main/java/com/github/backend/web/dto/UnapprovedMateDto.java
+++ b/src/main/java/com/github/backend/web/dto/UnapprovedMateDto.java
@@ -1,0 +1,10 @@
+package com.github.backend.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class UnapprovedMateDto {
+    private String unapprovedReason;
+}

--- a/src/main/java/com/github/backend/web/dto/mates/MateDto.java
+++ b/src/main/java/com/github/backend/web/dto/mates/MateDto.java
@@ -1,4 +1,4 @@
-package com.github.backend.web.dto;
+package com.github.backend.web.dto.mates;
 
 import com.github.backend.web.entity.enums.Gender;
 import lombok.*;
@@ -13,6 +13,7 @@ import java.util.List;
 public class MateDto {
     private String mateId;
     private String email;
+    private String phoneNum;
     private Gender mateGender;
     private String mateName;        // 메이트 본명 엔티티에 필드 생기면 주석 해제
     private String registrationNum; // 주민등록번호 엔티티에 생기면 주석 해제

--- a/src/main/java/com/github/backend/web/entity/MateEntity.java
+++ b/src/main/java/com/github/backend/web/entity/MateEntity.java
@@ -69,6 +69,11 @@ public class MateEntity extends BaseEntity{
   @Schema(description = "삭제여부", example = "Y")
   private String isDeleted;
 
+  @Column(name = "is_blacklisted", length = 10)
+  @Schema(description = "블랙리스트등록여부", example = "true")
+  private boolean isBlacklisted;
+
+
   @Column(name = "register_status", length = 10)
   @Schema(description = "등록현황", example = "인증 전")
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/github/backend/web/entity/UserEntity.java
+++ b/src/main/java/com/github/backend/web/entity/UserEntity.java
@@ -64,6 +64,11 @@ public class UserEntity extends BaseEntity{
     @Schema(description = "삭제여부", example = "Y")
     private String isDeleted;
 
+    @Column(name = "is_blacklisted", length = 10)
+    @Schema(description = "블랙리스트등록여부", example = "true")
+    private boolean isBlacklisted;
+
+
     @Builder
     public UserEntity(String userId, String password, String email, String name, String phoneNumber, String address, Gender gender, RolesEntity roles, String isDeleted){
       this.userId = userId;


### PR DESCRIPTION
- 관리자의 메이트 상세조회시 핸드폰번호 조회 추가 (dto)
- 관리자의 메이트 인증 승인과 미승인 로직을 나눔
- 메이트 미승인 시에는 사유를 적기 때문에, 사유를 받기위한 dto 생성(UnapprovedMateDto)
- 블랙리스트 관련 필드 유저엔티티 및 메이트엔티티에 추가
- coolsms 메세지 발송관련 현재 요금부족으로 서버 에러(500)가 발생해 주석처리 해놓음