### PR TITLE
fix: 메이트API 서비스로직 수정

### DIFF
--- a/src/main/java/com/github/backend/web/controller/MateController.java
+++ b/src/main/java/com/github/backend/web/controller/MateController.java
@@ -52,9 +52,9 @@ public class MateController {
     @Operation(summary = "도움 지원하기", description = "진행중인 도움 모집건에 지원한다.")
     @PostMapping("/{careCid}")
     public CommonResponseDto applyCaring(@PathVariable Long careCid,
-                                         @AuthenticationPrincipal CustomUserDetails customUserDetails){
+                                         @AuthenticationPrincipal CustomMateDetails customMateDetails){
         log.info("[GET] 메이트 로그인 후 메인화면 조회 요청 들어왔습니다");
-        return mateService.applyCaring(careCid,customUserDetails);
+        return mateService.applyCaring(careCid,customMateDetails);
     }
 
     @Operation(summary = "도움 완료하기", description = "도움을 끝내고 도움 완료한다")
@@ -84,9 +84,9 @@ public class MateController {
     @GetMapping("/CareHistory")
     public ResponseEntity<List<CaringDto>> viewApplyList(
             @RequestParam String careStatus,
-            @AuthenticationPrincipal CustomUserDetails customUserDetails
+            @AuthenticationPrincipal CustomMateDetails customMateDetails
     ){
-        List<CaringDto> caringList = mateService.viewApplyList(careStatus,customUserDetails);
+        List<CaringDto> caringList = mateService.viewApplyList(careStatus,customMateDetails);
         return ResponseEntity.ok().body(caringList);
     }
 
@@ -104,9 +104,9 @@ public class MateController {
     @GetMapping("/detailCare/{careCid}")
     public ResponseEntity<CaringDetailsDto> viewDetailCareList(
             @PathVariable Long careCid,
-            @AuthenticationPrincipal CustomUserDetails customUserDetails
+            @AuthenticationPrincipal CustomMateDetails customMateDetails
     ){
-        CaringDetailsDto careDetail = mateService.viewCareDetail(careCid,customUserDetails);
+        CaringDetailsDto careDetail = mateService.viewCareDetail(careCid);
         return ResponseEntity.ok().body(careDetail);
     }
 

--- a/src/main/java/com/github/backend/web/entity/MateCareHistoryEntity.java
+++ b/src/main/java/com/github/backend/web/entity/MateCareHistoryEntity.java
@@ -30,7 +30,7 @@ public class MateCareHistoryEntity {
     private MateEntity mate;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "care_cid", referencedColumnName = "mate_cid")
+    @JoinColumn(name = "care_cid", referencedColumnName = "care_cid")
     private CareEntity care;
 
 


### PR DESCRIPTION
- CustomUserDetails에서 CustomMateDetails로 변경
- CaringDetailsDto에 필요한 content, userId, careCid의 builder누락으로 추가
- 한번도 평가받은적없는 메이트의경우 마이페이지 접속시 MateRatingEntity에서 메이트 정보 찾을수없는 오류 해결 (Optional로 메이트에 해당하는 값이 없을시 0으로 출력)