### PR TITLE
fix: 관리자 api 수정

### DIFF
--- a/src/main/java/com/github/backend/config/security/SecurityConfig.java
+++ b/src/main/java/com/github/backend/config/security/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
 
     // 관리자 권한이 필요한 api
     private final String[] ADMIN_URL = {
-            "/api/admin/**"
+            "/api/master/**"
     };
 
     // 사용자 페이지 api

--- a/src/main/java/com/github/backend/repository/AuthRepository.java
+++ b/src/main/java/com/github/backend/repository/AuthRepository.java
@@ -1,9 +1,11 @@
 package com.github.backend.repository;
 
+import com.github.backend.web.entity.RolesEntity;
 import com.github.backend.web.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +13,6 @@ public interface AuthRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByUserId(String userId);
 
     boolean existsByUserId(String userId);
+
+    List<UserEntity> findAllByRoles(RolesEntity roles);
 }

--- a/src/main/java/com/github/backend/repository/RolesRepository.java
+++ b/src/main/java/com/github/backend/repository/RolesRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface RolesRepository extends JpaRepository<RolesEntity, Long> {
     boolean existsByRolesName(String roleName);
+
+    RolesEntity findByRolesName(String roleName);
 }

--- a/src/main/java/com/github/backend/service/MasterService.java
+++ b/src/main/java/com/github/backend/service/MasterService.java
@@ -2,13 +2,17 @@ package com.github.backend.service;
 
 import com.github.backend.repository.AuthRepository;
 import com.github.backend.repository.MateRepository;
+import com.github.backend.repository.RolesRepository;
 import com.github.backend.service.mapper.MateMapper;
 import com.github.backend.service.mapper.UserMapper;
 import com.github.backend.web.dto.CommonResponseDto;
 import com.github.backend.web.dto.UnapprovedMateDto;
+import com.github.backend.web.dto.UserDetailDto;
+import com.github.backend.web.dto.UserDto;
+import com.github.backend.web.dto.mates.MateDetailDto;
 import com.github.backend.web.dto.mates.MateDto;
-import com.github.backend.web.dto.RegisteredUser;
 import com.github.backend.web.entity.MateEntity;
+import com.github.backend.web.entity.RolesEntity;
 import com.github.backend.web.entity.UserEntity;
 import com.github.backend.web.entity.enums.MateStatus;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +29,7 @@ public class MasterService {
     private final MateRepository mateRepository;
     private final SendMessageService sendMessageService;
     private final AuthRepository authRepository;
+    private final RolesRepository rolesRepository;
 
 
     // 메이트 부분
@@ -52,13 +57,13 @@ public class MasterService {
 
 
 
-    public List<MateDto> findApplyMateList() {
+    public List<MateDto> findAllMateList() {
         log.info("[GET:MASTER] 관리자의 메이트 조회 요청이 들어왔습니다.");
-        List<MateEntity> mateList = mateRepository.findAllByMateStatus(MateStatus.PREPARING);
+        List<MateEntity> mateList = mateRepository.findAll();
         return mateList.stream().map(MateMapper.INSTANCE::MateEntityToDTO).toList();
     }
 
-    public MateDto findMate(Long mateCid) {
+    public MateDetailDto findMate(Long mateCid) {
         log.info("[GET:MASTER] 관리자의 메이트 상세 조회 요청이 들어왔습니다.");
         MateEntity mate = mateRepository.findById(mateCid).orElseThrow();
 //        String registrationNumber="";
@@ -66,11 +71,14 @@ public class MasterService {
 //            registrationNumber += mate.getRegistrationNum().charAt(i)+"";
 //        }
 //        registrationNumber += "******";
-        return MateDto.builder()
+        return MateDetailDto.builder()
+                .mateId(mate.getMateId())
                 .phoneNum(mate.getPhoneNumber())
                 .email(mate.getEmail())
                 .registrationNum(mate.getRegistrationNum()) // 뒷자리 첫번째까지만 공개
-                .mateGender(mate.getGender()).mateName(mate.getName())
+                .mateGender(mate.getGender())
+                .mateName(mate.getName())
+                .mateStatus(mate.getMateStatus())
                 .build();
     }
 
@@ -84,9 +92,10 @@ public class MasterService {
 
 
     // 사용자 부분
-    public List<RegisteredUser> findAllUserList() {
+    public List<UserDto> findAllUserList() {
         log.info("[GET:MASTER] 관리자의 사용자 조회 요청이 들어왔습니다.");
-        List<UserEntity> userList = authRepository.findAll();
+        RolesEntity roles = rolesRepository.findByRolesName("ROLE_USER");
+        List<UserEntity> userList = authRepository.findAllByRoles(roles);
         return userList.stream().map(UserMapper.INSTANCE::userEntityToDTO).toList();
     }
 
@@ -100,10 +109,11 @@ public class MasterService {
     }
 
 
-    public RegisteredUser findUser(Long userCid) {
+    public UserDetailDto findUser(Long userCid) {
         log.info("[GET:MASTER] 관리자의 사용자 상세 조회 요청이 들어왔습니다.");
         UserEntity user = authRepository.findById(userCid).orElseThrow();
-        return RegisteredUser.builder()
+        return UserDetailDto.builder()
+                .userId(user.getUserId())
                 .userGender(user.getGender())
                 .userName(user.getName())
                 .phone(user.getPhoneNumber())

--- a/src/main/java/com/github/backend/service/mapper/MateMapper.java
+++ b/src/main/java/com/github/backend/service/mapper/MateMapper.java
@@ -11,10 +11,8 @@ public interface MateMapper {
     MateMapper INSTANCE = Mappers.getMapper(MateMapper.class);
 
     @Mapping(target="mateId",source="mateId")
-    @Mapping(target="email",source="email")
-    @Mapping(target="mateName",source="name") // mateEntity에 본명 생기면 주석해제
+    @Mapping(target="mateName",source="name")
     @Mapping(target="mateGender",source="gender")
-    @Mapping(target="registrationNum",source="registrationNum") // mateEntity에 주민등록번호 생기면 주석해제
     MateDto MateEntityToDTO(MateEntity mateEntity);
 
 }

--- a/src/main/java/com/github/backend/service/mapper/UserMapper.java
+++ b/src/main/java/com/github/backend/service/mapper/UserMapper.java
@@ -1,16 +1,17 @@
 package com.github.backend.service.mapper;
-import com.github.backend.web.dto.RegisteredUser;
+import com.github.backend.web.dto.UserDto;
 import com.github.backend.web.entity.MateEntity;
 import com.github.backend.web.entity.UserEntity;
+import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
+@Mapper
 public interface UserMapper {
     UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
 
-    @Mapping(target="name",source="name") // userEntity에 본명추가시 주석 해제
-    @Mapping(target="phone",source="phoneNumber")
-    @Mapping(target="email",source="email")
+    @Mapping(target="userName",source="name")
+    @Mapping(target="userId",source = "userId")
     @Mapping(target="userGender",source="gender")
-    RegisteredUser userEntityToDTO(UserEntity userEntity);
+    UserDto userEntityToDTO(UserEntity userEntity);
 }

--- a/src/main/java/com/github/backend/web/controller/MasterController.java
+++ b/src/main/java/com/github/backend/web/controller/MasterController.java
@@ -3,14 +3,17 @@ package com.github.backend.web.controller;
 import com.github.backend.service.MasterService;
 import com.github.backend.web.dto.CommonResponseDto;
 import com.github.backend.web.dto.UnapprovedMateDto;
+import com.github.backend.web.dto.UserDetailDto;
+import com.github.backend.web.dto.UserDto;
+import com.github.backend.web.dto.mates.MateDetailDto;
 import com.github.backend.web.dto.mates.MateDto;
-import com.github.backend.web.dto.RegisteredUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import retrofit2.http.Path;
 
 import java.util.List;
 
@@ -23,7 +26,7 @@ public class MasterController {
     private final MasterService masterService;
 
 @Operation(summary = "메이트 승인하기", description = "메이트로 인증요청한 회원을 승인한다.")
-@PutMapping("/approve/{mateCid}")
+@PostMapping("/approve/{mateCid}")
 public CommonResponseDto approveMate(
         @PathVariable Long mateCid){
     log.info("[PUT] 메이트 인증승인 요청 들어왔습니다");
@@ -31,7 +34,7 @@ public CommonResponseDto approveMate(
 }
 
 @Operation(summary = "메이트 미승인하기", description = "메이트로 인증요청한 회원을 미승인한다.")
-@PutMapping("/unapproved/{mateCid}")
+@PostMapping("/unapprove/{mateCid}")
 public CommonResponseDto unapprovedMate(
         @PathVariable Long mateCid,
         UnapprovedMateDto unapprovedMateDto){
@@ -42,57 +45,54 @@ public CommonResponseDto unapprovedMate(
 
 
 
-@Operation(summary = "메이트 신청목록 확인", description = "메이트로 회원가입 신청한 회원 목록을 조회한다")
+@Operation(summary = "메이트 목록 확인", description = "메이트 회원 목록을 조회한다")
 @GetMapping("/mate")
 public ResponseEntity<List<MateDto>> viewMateList(){
-    log.info("[GET] 메이트 신청 회원 목록 조회 요청 들어왔습니다.");
-    List<MateDto> applyMateDto = masterService.findApplyMateList();
-    return ResponseEntity.ok().body(applyMateDto);
+    log.info("[GET] 메이트 회원 목록 조회 요청 들어왔습니다.");
+    List<MateDto> mates = masterService.findAllMateList();
+    return ResponseEntity.ok().body(mates);
 }
 
 
 
 @Operation(summary = "메이트 상세 확인", description = "메이트 정보를 조회한다")
 @GetMapping("/mate/{mateCid}")
-public ResponseEntity<MateDto> viewMate(@PathVariable Long mateCid){
+public ResponseEntity<MateDetailDto> viewMate(@PathVariable Long mateCid){
     log.info("[GET] 메이트 상세 조회 요청 들어왔습니다");
-    MateDto mateDetail = masterService.findMate(mateCid);
+    MateDetailDto mateDetail = masterService.findMate(mateCid);
     return ResponseEntity.ok().body(mateDetail);
 }
 
 @Operation(summary = "메이트 블랙리스트 전환", description = "메이트 블랙리스트 유무를 체크한다")
-@PutMapping("/mate")
+@PutMapping("/mate/{mateCid}")
 public CommonResponseDto blackingMate(@RequestParam boolean isBlacklisted,
-                                      @RequestParam Long mateCid){
+                                      @PathVariable Long mateCid){
     return masterService.blacklistingMate(isBlacklisted,mateCid);
 }
-
-
-
 
 
 // 사용자 관리
 
 @Operation(summary = "사용자 리스트 확인", description = "사용자 목록을 조회한다")
 @GetMapping("/user")
-public ResponseEntity<List<RegisteredUser>> viewUserList(){
+public ResponseEntity<List<UserDto>> viewUserList(){
     log.info("[GET] 사용자 목록 조회 요청 들어왔습니다");
-    List<RegisteredUser> UserList = masterService.findAllUserList();
+    List<UserDto> UserList = masterService.findAllUserList();
     return ResponseEntity.ok().body(UserList);
 }
 
 @Operation(summary = "사용자 상세 확인", description = "사용자 정보를 조회한다")
 @GetMapping("/user/{userCid}")
-public ResponseEntity<RegisteredUser> viewUser(@PathVariable Long userCid){
+public ResponseEntity<UserDetailDto> viewUser(@PathVariable Long userCid){
     log.info("[GET] 사용자 상세 조회 요청 들어왔습니다");
-    RegisteredUser userDetail = masterService.findUser(userCid);
+    UserDetailDto userDetail = masterService.findUser(userCid);
     return ResponseEntity.ok().body(userDetail);
 }
 
 @Operation(summary = "사용자 블랙리스트 전환", description = "사용자 블랙리스트 유무를 체크한다")
-@PutMapping("/user")
+@PutMapping("/user/{userCid}")
 public CommonResponseDto blackingUser(@RequestParam boolean isBlacklisted,
-                                      @RequestParam Long userCid){
+                                      @PathVariable Long userCid){
     return masterService.blacklistingUser(isBlacklisted,userCid);
 }
 }

--- a/src/main/java/com/github/backend/web/dto/UserDetailDto.java
+++ b/src/main/java/com/github/backend/web/dto/UserDetailDto.java
@@ -1,0 +1,17 @@
+package com.github.backend.web.dto;
+
+import com.github.backend.web.entity.enums.Gender;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class UserDetailDto {
+    private String userId;
+    private String userName;
+    private String phone;
+    private String email;
+    private Gender userGender;
+}

--- a/src/main/java/com/github/backend/web/dto/UserDto.java
+++ b/src/main/java/com/github/backend/web/dto/UserDto.java
@@ -8,10 +8,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
-public class RegisteredUser {
-
+public class UserDto {
+    private String userId;
     private String userName;
-    private String phone;
-    private String email;
     private Gender userGender;
 }

--- a/src/main/java/com/github/backend/web/dto/mates/MateDetailDto.java
+++ b/src/main/java/com/github/backend/web/dto/mates/MateDetailDto.java
@@ -1,15 +1,19 @@
 package com.github.backend.web.dto.mates;
 
 import com.github.backend.web.entity.enums.Gender;
+import com.github.backend.web.entity.enums.MateStatus;
 import lombok.*;
 
-import java.util.List;
 
 @Getter
 @Setter
 @Builder
-public class MateDto {
+public class MateDetailDto {
     private String mateId;
+    private String email;
+    private String phoneNum;
     private Gender mateGender;
     private String mateName;
+    private String registrationNum;
+    private MateStatus mateStatus;
 }


### PR DESCRIPTION
- 메이트/사용자 전체조회 상세조회시 응답 dto를 2개로 나눔 (UserDto,UserDetailDto ..)
- PutMapping->Postmapping(상태변경시에는 put보다 post가 restful하다고함..)
- 관리자가 전체 메이트를 조회할수있도록 로직 변경
- 메이트 상세조회시 해당 메이트의 인증상태가 대기중이냐 완료이냐에 따라 승인 미승인 버튼을 활성화시키라는 의미로 응답dto(MateDetailDto)에 mateStatus필드 추가.
- 위 로직변경에 따른 mapper 및 레포지토리 변경