### PR TITLE
fix: 메이트api 로직 수정

### DIFF
--- a/src/main/java/com/github/backend/repository/ServiceApplyRepository.java
+++ b/src/main/java/com/github/backend/repository/ServiceApplyRepository.java
@@ -4,6 +4,7 @@ import com.github.backend.web.entity.CareEntity;
 import com.github.backend.web.entity.MateEntity;
 import com.github.backend.web.entity.UserEntity;
 import com.github.backend.web.entity.enums.CareStatus;
+import com.github.backend.web.entity.enums.MateCareStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,8 +13,6 @@ import java.util.List;
 
 @Repository
 public interface ServiceApplyRepository extends JpaRepository<CareEntity, Long > {
-
-    List<CareEntity> findAllByMateAndCareStatus(MateEntity mate, CareStatus status);
 
     List<CareEntity> findAllByCareStatus(CareStatus careStatus);
 

--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -2,19 +2,18 @@ package com.github.backend.service;
 
 import com.github.backend.repository.*;
 import com.github.backend.service.exception.CommonException;
+import com.github.backend.service.exception.InvalidValueException;
 import com.github.backend.service.exception.NotFoundException;
 import com.github.backend.service.mapper.MateCaringMapper;
 import com.github.backend.web.dto.CommonResponseDto;
+import com.github.backend.web.dto.apply.UserDto;
 import com.github.backend.web.dto.mates.CaringDetailsDto;
 import com.github.backend.web.dto.mates.CaringDto;
 import com.github.backend.web.dto.mates.MainPageDto;
 import com.github.backend.web.dto.mates.MyPageDto;
 import com.github.backend.web.dto.users.RequestUpdateDto;
 import com.github.backend.web.dto.users.ResponseMyInfoDto;
-import com.github.backend.web.entity.CareEntity;
-import com.github.backend.web.entity.MateCareHistoryEntity;
-import com.github.backend.web.entity.MateEntity;
-import com.github.backend.web.entity.MateRatingEntity;
+import com.github.backend.web.entity.*;
 import com.github.backend.web.entity.custom.CustomMateDetails;
 import com.github.backend.web.entity.custom.CustomUserDetails;
 import com.github.backend.web.entity.enums.CareStatus;
@@ -27,8 +26,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import static com.github.backend.web.dto.apply.UserDto.careEntityToUserDto;
 
 @Service
 @Slf4j
@@ -44,6 +46,7 @@ public class MateService {
     private final RatingRepository ratingRepository;
     private final SendMessageService sendMessageService;
 
+    @Transactional
     public CommonResponseDto applyCaring(Long careId, CustomMateDetails customMateDetails) {
         Long mateId = customMateDetails.getMate().getMateCid();
         CareEntity care = careRepository.findById(careId).orElseThrow();
@@ -52,7 +55,7 @@ public class MateService {
         List<MateCareHistoryEntity> mateCareHistoryEntities = mateCareHistoryRepository.findAllByMateAndMateCareStatus(mate, MateCareStatus.IN_PROGRESS);
         List<CareEntity> careEntities = mateCareHistoryEntities.stream().map(MateCareHistoryEntity::getCare).toList();
         for (CareEntity caring : careEntities) {
-            if (caring.getCareDate() == care.getCareDate()) {
+            if (caring.getCareDate().equals(care.getCareDate())) {
                 return CommonResponseDto.builder().code(404).success(false).message("이미 같은 날짜에 신청한 도움이 있어, 신청이 불가능합니다!").build();
             }
         }
@@ -98,12 +101,27 @@ public class MateService {
 
     ;
 
+    @Transactional
     public List<CaringDto> viewApplyList(String careStatus,CustomMateDetails customMateDetails) {
         MateEntity mate = mateRepository.findById(customMateDetails.getMate().getMateCid()).orElseThrow();
-        CareStatus status = CareStatus.valueOf(careStatus);
-        List<CareEntity> careList = careRepository.findAllByMateAndCareStatus(mate, status);
-        return careList.stream().map(MateCaringMapper.INSTANCE::CareEntityToDTO).toList();
-    }
+        MateCareStatus mateCareStatus;
+            if (careStatus.equalsIgnoreCase("IN_PROGRESS")) {
+                mateCareStatus = MateCareStatus.IN_PROGRESS;
+            } else if (careStatus.equalsIgnoreCase("HELP_DONE")){
+            mateCareStatus = MateCareStatus.HELP_DONE;
+            }
+            else if(careStatus.equalsIgnoreCase("cancel")) {
+            mateCareStatus = MateCareStatus.CANCEL;
+            }
+            else {
+            throw new InvalidValueException("상태를 잘못입력하였습니다. 다시 입력해주세요.");
+            }
+        List<MateCareHistoryEntity> mateCareHistoryList = mateCareHistoryRepository.findAllByMateAndMateCareStatus(mate, mateCareStatus);
+        List<CareEntity> careList = mateCareHistoryList.stream().map(MateCareHistoryEntity::getCare).toList();
+            return careList.stream().map(MateCaringMapper.INSTANCE::CareEntityToDTO).toList();
+
+        }
+
 
 
     // 신규요청 내역 조회하기(대기중인 도움들 전체 조회)

--- a/src/main/java/com/github/backend/web/entity/MateCareHistoryEntity.java
+++ b/src/main/java/com/github/backend/web/entity/MateCareHistoryEntity.java
@@ -23,6 +23,7 @@ public class MateCareHistoryEntity {
 
     @Column
     @Schema(description = "메이트의 도움 상태",example = "취소")
+    @Enumerated(EnumType.STRING)
     private MateCareStatus mateCareStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
- mateCareStatus의 db저장 방식을 숫자타입에서 string타입으로 변경
- 같은날짜에 이미 신청한 도움서비스가 있으면 신청못하게 변경
- lazyinitializationexception 발생으로 @Transactional 추가
- MatecareStatus별로 목록 요청시 status 대소문자 구분없이 일치하는 enum값찾도록 viewApplyList 메서드 수정