### PR TITLE
fix: 관리자가 유저 메이트 조회시 cid 필드 추가

### DIFF
--- a/src/main/java/com/github/backend/service/mapper/MateMapper.java
+++ b/src/main/java/com/github/backend/service/mapper/MateMapper.java
@@ -10,6 +10,7 @@ import org.mapstruct.factory.Mappers;
 public interface MateMapper {
     MateMapper INSTANCE = Mappers.getMapper(MateMapper.class);
 
+    @Mapping(target="cid",source="mateCid")
     @Mapping(target="mateId",source="mateId")
     @Mapping(target="mateName",source="name")
     @Mapping(target="mateGender",source="gender")

--- a/src/main/java/com/github/backend/service/mapper/UserMapper.java
+++ b/src/main/java/com/github/backend/service/mapper/UserMapper.java
@@ -9,6 +9,7 @@ import org.mapstruct.factory.Mappers;
 public interface UserMapper {
     UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
 
+    @Mapping(target="cid",source = "userCid")
     @Mapping(target="userName",source="name")
     @Mapping(target="userId",source = "userId")
     @Mapping(target="userGender",source="gender")

--- a/src/main/java/com/github/backend/web/dto/master/MateDto.java
+++ b/src/main/java/com/github/backend/web/dto/master/MateDto.java
@@ -10,6 +10,9 @@ import java.util.List;
 @Setter
 @Builder
 public class MateDto {
+
+    @Schema(description = "메이트 cid", example = "1")
+    private Long cid;
     @Schema(description = "메이트 아이디",example = "linxizhu129")
     private String mateId;
     @Schema(description = "메이트 성별",example = "MEN/WOMEN")

--- a/src/main/java/com/github/backend/web/dto/master/UserListDto.java
+++ b/src/main/java/com/github/backend/web/dto/master/UserListDto.java
@@ -11,6 +11,8 @@ import lombok.Setter;
 @Builder
 public class UserListDto {
 
+    @Schema(description = "사용자 cid", example = "2")
+    private Long cid;
     @Schema(description = "사용자 아이디",example = "linxizhu129")
     private String userId;
     @Schema(description = "사용자 본명",example = "김용용")


### PR DESCRIPTION
- 이유 : 사용자 상세 조회할 때 cid로 조회하는데 값을 주지 않으면 프론트에서 확인이 불가하기 때문에