### PR TITLE
Fix: chatting로직 수정

### DIFF
--- a/src/main/java/com/github/backend/config/security/handler/StompHandler.java
+++ b/src/main/java/com/github/backend/config/security/handler/StompHandler.java
@@ -27,11 +27,6 @@ public class StompHandler implements ChannelInterceptor {
             jwtTokenProvider.validationToken(result);
         }
 
-
-
-
         return message;
-
     }
-
 }

--- a/src/main/java/com/github/backend/repository/ChatRepository.java
+++ b/src/main/java/com/github/backend/repository/ChatRepository.java
@@ -12,5 +12,5 @@ import java.util.List;
 public interface ChatRepository extends JpaRepository<ChatEntity, Long> {
 
 
-    List<ChatEntity> findChatEntitiesByChatRoom(ChatRoomEntity chatRoom);
+    List<ChatEntity> findChatEntitiesByChatRoomCid(Long chatRoomCid);
 }

--- a/src/main/java/com/github/backend/repository/ChatRepository.java
+++ b/src/main/java/com/github/backend/repository/ChatRepository.java
@@ -12,5 +12,5 @@ import java.util.List;
 public interface ChatRepository extends JpaRepository<ChatEntity, Long> {
 
 
-    List<ChatEntity> findChatEntitiesByChatRoomCid(Long chatRoomCid);
+    List<ChatEntity> findChatEntitiesByChatRoom(ChatRoomEntity chatRoom);
 }

--- a/src/main/java/com/github/backend/repository/ChatRoomRepository.java
+++ b/src/main/java/com/github/backend/repository/ChatRoomRepository.java
@@ -13,10 +13,9 @@ import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
-    Optional<ChatRoomEntity> findByUserAndMate(UserEntity user, MateEntity mate);
 
-    List<ChatRoomEntity> findAllByUser(UserEntity user);
+    List<ChatRoomEntity> findAllByUserCid(Long userCid);
 
 
-    List<ChatRoomEntity> findAllByMate(MateEntity mate);
+    List<ChatRoomEntity> findAllByMateCid(Long mateCid);
 }

--- a/src/main/java/com/github/backend/service/ChatRoomService.java
+++ b/src/main/java/com/github/backend/service/ChatRoomService.java
@@ -65,7 +65,7 @@ public class ChatRoomService {
         }
         else{
             log.info("해당 채팅방의 채팅 이력을 보여줍니다.");
-            List<ChatEntity> chatList = chatRepository.findChatEntitiesByChatRoomCid(chatRoom.getChatRoomCid());
+            List<ChatEntity> chatList = chatRepository.findChatEntitiesByChatRoom(chatRoom);
             // 채팅 엔티티 -> 채팅 dto
             List<ChatMessageResponseDto> chatHistory = chatList.stream().map(ChatMapper.INSTANCE::chatEntityToDTO).toList();
             // 채팅 dto를 줄때, user와 mate를 나눠서 각각 주는게 나은가? .............

--- a/src/main/java/com/github/backend/service/ChatRoomService.java
+++ b/src/main/java/com/github/backend/service/ChatRoomService.java
@@ -16,7 +16,10 @@ import org.mapstruct.control.MappingControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 
@@ -31,11 +34,14 @@ public class ChatRoomService {
     private final AuthRepository authRepository;
     private final MateRepository mateRepository;
 
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy.MM.dd. a h:mm");
+
+
     @Transactional
     public Long createRoom(CareEntity care){
         log.info("채팅방 생성 요청 들어왔습니다.");
-        ChatRoomEntity chatRoom = ChatRoomEntity.builder().careCid(care.getCareCid()).build();
-        ChatRoomEntity newChatRoom = chatRoomRepository.save(chatRoom);
+
+        ChatRoomEntity newChatRoom = chatRoomRepository.save(ChatRoomEntity.builder().careCid(care.getCareCid()).build());
         return newChatRoom.getChatRoomCid();
     }
 
@@ -75,11 +81,16 @@ public class ChatRoomService {
 
         for (ChatRoomEntity chatRoom : chatRooms) {
             UserEntity user = authRepository.findById(chatRoom.getUserCid()).orElseThrow();
+            String formattedTime = chatRoom.getUpdatedAt().format(formatter);
             ChatRoomResponseDto chatRoomResponseDto = ChatRoomResponseDto.builder()
+                    .chatRoomCid(chatRoom.getChatRoomCid())
                     .name(user.getName())
+                    .time(formattedTime)
                     .build();
             chatRoomResponseDtos.add(chatRoomResponseDto);
         }
+
+        chatRoomResponseDtos.sort(Comparator.comparing(ChatRoomResponseDto::getTime).reversed());
         return chatRoomResponseDtos;
     }
 
@@ -91,11 +102,15 @@ public class ChatRoomService {
 
         for (ChatRoomEntity chatRoom : chatRooms) {
             MateEntity mate = mateRepository.findById(chatRoom.getMateCid()).orElseThrow();
+            String formattedTime = chatRoom.getUpdatedAt().format(formatter);
             ChatRoomResponseDto chatRoomResponseDto = ChatRoomResponseDto.builder()
+                    .chatRoomCid(chatRoom.getChatRoomCid())
                     .name(mate.getName())
+                    .time(formattedTime)
                     .build();
             chatRoomResponseDtos.add(chatRoomResponseDto);
         }
+        chatRoomResponseDtos.sort(Comparator.comparing(ChatRoomResponseDto::getTime).reversed());
         return chatRoomResponseDtos;
     }
 }

--- a/src/main/java/com/github/backend/service/ChatRoomService.java
+++ b/src/main/java/com/github/backend/service/ChatRoomService.java
@@ -2,6 +2,8 @@ package com.github.backend.service;
 
 
 import com.github.backend.repository.*;
+import com.github.backend.service.mapper.ChatMapper;
+import com.github.backend.web.dto.chatDto.ChatMessageResponseDto;
 import com.github.backend.web.dto.chatDto.ChatRoomResponseDto;
 import com.github.backend.web.dto.CommonResponseDto;
 import com.github.backend.web.entity.*;
@@ -10,6 +12,7 @@ import com.github.backend.web.entity.custom.CustomUserDetails;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.mapstruct.control.MappingControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -25,12 +28,13 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final ServiceApplyRepository serviceApplyRepository;
     private final ChatRepository chatRepository;
+    private final AuthRepository authRepository;
+    private final MateRepository mateRepository;
 
     @Transactional
     public Long createRoom(CareEntity care){
         log.info("채팅방 생성 요청 들어왔습니다.");
-        ChatRoomEntity chatRoom = ChatRoomEntity.builder()
-                .chatRoomName(care.getContent()).build();
+        ChatRoomEntity chatRoom = ChatRoomEntity.builder().careCid(care.getCareCid()).build();
         ChatRoomEntity newChatRoom = chatRoomRepository.save(chatRoom);
         return newChatRoom.getChatRoomCid();
     }
@@ -39,15 +43,15 @@ public class ChatRoomService {
     public ResponseEntity enterChatRoom(Long chatRoomCid) {
         log.info("채팅방 입장 요청 들어왔습니다");
         ChatRoomEntity chatRoom = chatRoomRepository.findById(chatRoomCid).orElseThrow();
-        if(chatRoom.getMate()==null){
-            String chatRoomName = chatRoom.getChatRoomName();
-            CareEntity care = serviceApplyRepository.findCareEntityByContent(chatRoomName);
+        if(chatRoom.getMateCid()==null){
+            Long careCid = chatRoom.getCareCid();
+            CareEntity care = serviceApplyRepository.findById(careCid).orElseThrow();
             UserEntity user = care.getUser();
             MateEntity mate = care.getMate();
             log.info("채팅 이력이 존재하지 않아, 채팅 참가자를 설정했습니다." +
                     " 참가 UserId:"+user.getUserId()+", 참가 MateId:"+mate.getMateId());
-            chatRoom.setUser(user);
-            chatRoom.setMate(mate);
+            chatRoom.setUserCid(user.getUserCid());
+            chatRoom.setMateCid(mate.getMateCid());
             chatRoomRepository.save(chatRoom);
             CommonResponseDto returnDto =  CommonResponseDto.builder().code(200).success(true)
                     .message("채팅방 참가자 설정이 완료되었습니다. 대화를 시작해주세요").build();
@@ -55,39 +59,41 @@ public class ChatRoomService {
         }
         else{
             log.info("해당 채팅방의 채팅 이력을 보여줍니다.");
-            List<ChatEntity> chatList = chatRepository.findChatEntitiesByChatRoom(chatRoom);
-            return ResponseEntity.ok().body(chatList);
+            List<ChatEntity> chatList = chatRepository.findChatEntitiesByChatRoomCid(chatRoom.getChatRoomCid());
+            // 채팅 엔티티 -> 채팅 dto
+            List<ChatMessageResponseDto> chatHistory = chatList.stream().map(ChatMapper.INSTANCE::chatEntityToDTO).toList();
+            // 채팅 dto를 줄때, user와 mate를 나눠서 각각 주는게 나은가? .............
+            return ResponseEntity.ok().body(chatHistory);
         }
     }
 
     public List<ChatRoomResponseDto> findMateChatRoomList(CustomMateDetails customMateDetails) {
         log.info("해당 메이트가 참가하고 있는 대화방 목록 조회 요청이 들어왔습니다.");
         MateEntity mate = customMateDetails.getMate();
-        List<ChatRoomEntity> chatRooms = chatRoomRepository.findAllByMate(mate);
+        List<ChatRoomEntity> chatRooms = chatRoomRepository.findAllByMateCid(mate.getMateCid());
         List<ChatRoomResponseDto> chatRoomResponseDtos = new ArrayList<>();
 
         for (ChatRoomEntity chatRoom : chatRooms) {
+            UserEntity user = authRepository.findById(chatRoom.getUserCid()).orElseThrow();
             ChatRoomResponseDto chatRoomResponseDto = ChatRoomResponseDto.builder()
-                    .name(chatRoom.getUser().getName())
+                    .name(user.getName())
                     .build();
-
             chatRoomResponseDtos.add(chatRoomResponseDto);
         }
         return chatRoomResponseDtos;
-
     }
 
     public List<ChatRoomResponseDto> findUserChatRoomList(CustomUserDetails customUserDetails) {
         log.info("해당 사용자가 참가하고 있는 대화방 목록 조회 요청이 들어왔습니다.");
         UserEntity user = customUserDetails.getUser();
-        List<ChatRoomEntity> chatRooms = chatRoomRepository.findAllByUser(user);
+        List<ChatRoomEntity> chatRooms = chatRoomRepository.findAllByUserCid(user.getUserCid());
         List<ChatRoomResponseDto> chatRoomResponseDtos = new ArrayList<>();
 
         for (ChatRoomEntity chatRoom : chatRooms) {
+            MateEntity mate = mateRepository.findById(chatRoom.getMateCid()).orElseThrow();
             ChatRoomResponseDto chatRoomResponseDto = ChatRoomResponseDto.builder()
-                    .name(chatRoom.getMate().getName())
+                    .name(mate.getName())
                     .build();
-
             chatRoomResponseDtos.add(chatRoomResponseDto);
         }
         return chatRoomResponseDtos;

--- a/src/main/java/com/github/backend/service/ChatService.java
+++ b/src/main/java/com/github/backend/service/ChatService.java
@@ -38,14 +38,14 @@ public class ChatService {
             chatMessage = ChatEntity.builder()
                     .content(message.getMessage())
                     .sender(sender)
-                    .chatRoomCid(chatRoom.getChatRoomCid())
+                    .chatRoom(chatRoom)
                     .build();
         } else if (senderMate.getMateId().equals(sender)) {
             // 메시지를 보낸 사람이 Mate인 경우 처리
             chatMessage = ChatEntity.builder()
                     .content(message.getMessage())
                     .sender(sender)
-                    .chatRoomCid(chatRoom.getChatRoomCid())
+                    .chatRoom(chatRoom)
                     .build();
         } else {
             throw new IllegalArgumentException("메시지를 보낸 사용자를 찾을 수 없습니다.");
@@ -53,7 +53,6 @@ public class ChatService {
 
         if (chatMessage != null) {
             chatRepository.save(chatMessage); // chatRepository.save()를 한 번만 호출
-            chatRoom.setChatMessageMap(chatMessage);
             // 채팅 메시지를 구독 중인 클라이언트에게 전송
             messagingTemplate.convertAndSend("/queue/chat/message/" + chatRoom.getChatRoomCid(), chatMessage);
         }

--- a/src/main/java/com/github/backend/service/ChatService.java
+++ b/src/main/java/com/github/backend/service/ChatService.java
@@ -53,7 +53,7 @@ public class ChatService {
 
         if (chatMessage != null) {
             chatRepository.save(chatMessage); // chatRepository.save()를 한 번만 호출
-
+            chatRoom.setChatMessageMap(chatMessage);
             // 채팅 메시지를 구독 중인 클라이언트에게 전송
             messagingTemplate.convertAndSend("/queue/chat/message/" + chatRoom.getChatRoomCid(), chatMessage);
         }

--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -68,8 +68,8 @@ public class MateService {
         careRepository.save(care);
 
         ChatRoomEntity chatRoomEntity = ChatRoomEntity.builder()
-                .mate(mate)
-                .user(user)
+                .mateCid(mate.getMateCid())
+                .userCid(user.getUserCid())
                 .build();
 
         chatRoomRepository.save(chatRoomEntity);

--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -67,14 +67,6 @@ public class MateService {
         mateCareHistoryRepository.save(mateCareHistory);
         careRepository.save(care);
 
-        ChatRoomEntity chatRoomEntity = ChatRoomEntity.builder()
-                .mateCid(mate.getMateCid())
-                .userCid(user.getUserCid())
-                .build();
-
-        chatRoomRepository.save(chatRoomEntity);
-
-
         return CommonResponseDto.builder().code(200).success(true).message("도움 지원이 완료되었습니다!").build();
     }
 

--- a/src/main/java/com/github/backend/service/ServiceApplyService.java
+++ b/src/main/java/com/github/backend/service/ServiceApplyService.java
@@ -17,6 +17,7 @@ import com.github.backend.web.entity.UserEntity;
 import com.github.backend.web.entity.custom.CustomUserDetails;
 import com.github.backend.web.entity.enums.CareStatus;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +42,8 @@ public class ServiceApplyService {
     private final MateRepository mateRepository;
     private final RatingRepository ratingRepository;
     private final ChatRoomService chatRoomService;
+
+    @Transactional
     public CreatedChatRoomDto applyService(ServiceApplyDto serviceApplyDto, CustomUserDetails customUserDetails) {
         UserEntity userEntity = findById(customUserDetails);
 

--- a/src/main/java/com/github/backend/service/mapper/ChatMapper.java
+++ b/src/main/java/com/github/backend/service/mapper/ChatMapper.java
@@ -1,0 +1,21 @@
+package com.github.backend.service.mapper;
+
+import com.github.backend.web.dto.chatDto.ChatMessageResponseDto;
+import com.github.backend.web.dto.mates.CaringDto;
+import com.github.backend.web.entity.CareEntity;
+import com.github.backend.web.entity.ChatEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ChatMapper {
+
+    ChatMapper INSTANCE = Mappers.getMapper(ChatMapper.class);
+
+    @Mapping(target="sender",source="sender")
+    @Mapping(target="content",source="message")
+    @Mapping(target="timeStamp",source="createdAt")
+    ChatMessageResponseDto chatEntityToDTO(ChatEntity chatEntity);
+
+}

--- a/src/main/java/com/github/backend/web/dto/chatDto/ChatRoomResponseDto.java
+++ b/src/main/java/com/github/backend/web/dto/chatDto/ChatRoomResponseDto.java
@@ -7,11 +7,19 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
 @Getter
 @Builder
 public class ChatRoomResponseDto {
+    @Schema(name="채팅방 고유 번호")
+    private final Long chatRoomCid;
     @Schema(name="채팅 상대방 이름")
     private final String name;
+    @Schema(name="마지막 메시지 시간")
+    private final String time;
+
+
 }

--- a/src/main/java/com/github/backend/web/entity/BaseEntity.java
+++ b/src/main/java/com/github/backend/web/entity/BaseEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,6 +12,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 public abstract class BaseEntity {

--- a/src/main/java/com/github/backend/web/entity/ChatEntity.java
+++ b/src/main/java/com/github/backend/web/entity/ChatEntity.java
@@ -11,8 +11,19 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@EntityListeners(ChatEntity.ChatEntityListener.class)
 @Table(name = "chat_table")
 public class ChatEntity extends BaseEntity{
+
+    public static class ChatEntityListener {
+        @PrePersist
+        public void beforeSave(ChatEntity chat) {
+            if (chat.getChatRoom() != null) {
+                chat.getChatRoom().setUpdatedAt(LocalDateTime.now());
+            }
+        }
+    }
+
     @Id
     @Column(name = "chat_cid")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,16 +34,18 @@ public class ChatEntity extends BaseEntity{
     @Schema(description = "채팅내용", example = "응?")
     private String message;
 
+    @JsonBackReference
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name="chat_room_cid")
+    private ChatRoomEntity chatRoom;
 
-    @Column(name="chat_room_cid")
-    private Long chatRoomCid;
-
+    @Column(name="sender")
     private String sender;
 
     @Builder
-    public ChatEntity(String content, Long chatRoomCid, String sender) {
+    public ChatEntity(String content, ChatRoomEntity chatRoom, String sender) {
         this.message = content;
-        this.chatRoomCid = chatRoomCid;
+        this.chatRoom = chatRoom;
         this.sender = sender;
     }
 }

--- a/src/main/java/com/github/backend/web/entity/ChatEntity.java
+++ b/src/main/java/com/github/backend/web/entity/ChatEntity.java
@@ -24,17 +24,15 @@ public class ChatEntity extends BaseEntity{
     private String message;
 
 
-    @JsonBackReference
-    @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name="chat_room_cid")
-    private ChatRoomEntity chatRoom;
+    @Column(name="chat_room_cid")
+    private Long chatRoomCid;
 
     private String sender;
 
     @Builder
-    public ChatEntity(String content, ChatRoomEntity chatRoom, String sender) {
+    public ChatEntity(String content, Long chatRoomCid, String sender) {
         this.message = content;
-        this.chatRoom = chatRoom;
+        this.chatRoomCid = chatRoomCid;
         this.sender = sender;
     }
 }

--- a/src/main/java/com/github/backend/web/entity/ChatRoomEntity.java
+++ b/src/main/java/com/github/backend/web/entity/ChatRoomEntity.java
@@ -25,10 +25,13 @@ public class ChatRoomEntity extends BaseEntity{
     @Schema(description = "채팅 고유 아이디")
     private Long chatRoomCid;
 
-
     @Column(name = "care_cid")
     @Schema(description = "채팅방과 연관된 도움cid")
     private Long careCid;
+
+    @JsonManagedReference
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.REMOVE)
+    private List<ChatEntity> chatMessageList;
 
     @Column(name ="user_cid")
     private Long userCid;
@@ -36,15 +39,9 @@ public class ChatRoomEntity extends BaseEntity{
     @Column(name="mate_cid")
     private Long mateCid;
 
-    @JsonIgnore
-    @Transient
-    private Map<String,String> chatMessageMap = new HashMap<>();
-    // 보낸 사람과, 메시지를 저장
 
 
-    public void setChatMessageMap(ChatEntity chat) {
-        this.chatMessageMap.put(chat.getSender(),chat.getMessage());
-    }
+
 }
 
 

--- a/src/main/java/com/github/backend/web/entity/ChatRoomEntity.java
+++ b/src/main/java/com/github/backend/web/entity/ChatRoomEntity.java
@@ -22,19 +22,17 @@ public class ChatRoomEntity extends BaseEntity{
     @Schema(description = "채팅 고유 아이디")
     private Long chatRoomCid;
 
-    @Column(name = "chat_room_name")
-    @Schema(description = "채팅방 이름")
-    private String chatRoomName;
+    @Column(name = "care_cid")
+    @Schema(description = "채팅방과 연관된 도움cid")
+    private Long careCid;
 
-    @JsonManagedReference
-    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.REMOVE)
-    private List<ChatEntity> chatMessageList;
+//    @JsonManagedReference
+//    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.REMOVE)
+//    private List<ChatEntity> chatMessageList;
 
-    @ManyToOne
-    @JoinColumn(name = "user_cid")
-    private UserEntity user;
+    @Column(name ="user_cid")
+    private Long userCid;
 
-    @ManyToOne
-    @JoinColumn(name = "mate_cid")
-    private MateEntity mate;
+    @Column(name="mate_cid")
+    private Long mateCid;
 }

--- a/src/main/java/com/github/backend/web/entity/ChatRoomEntity.java
+++ b/src/main/java/com/github/backend/web/entity/ChatRoomEntity.java
@@ -1,12 +1,15 @@
 package com.github.backend.web.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @Setter
@@ -22,17 +25,26 @@ public class ChatRoomEntity extends BaseEntity{
     @Schema(description = "채팅 고유 아이디")
     private Long chatRoomCid;
 
+
     @Column(name = "care_cid")
     @Schema(description = "채팅방과 연관된 도움cid")
     private Long careCid;
-
-//    @JsonManagedReference
-//    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.REMOVE)
-//    private List<ChatEntity> chatMessageList;
 
     @Column(name ="user_cid")
     private Long userCid;
 
     @Column(name="mate_cid")
     private Long mateCid;
+
+    @JsonIgnore
+    @Transient
+    private Map<String,String> chatMessageMap = new HashMap<>();
+    // 보낸 사람과, 메시지를 저장
+
+
+    public void setChatMessageMap(ChatEntity chat) {
+        this.chatMessageMap.put(chat.getSender(),chat.getMessage());
+    }
 }
+
+


### PR DESCRIPTION
- ChatRoomEntity와 UserEntity, MateEntity 연관관계 삭제 -> userId와 mateId를 저장
- ChatEntity와 ChatRoomEntity의 연관관계 다시 설정
- ChatEntity가 생성될때 ChatRoomEntity의 updatedAt이 변동되도록 ChatEntity내 @EntityListenders 추가
- 메이트 및 사용자가 채팅방 전체 조회를 했을때, 채팅방의 updatedAt 시간에 따라 마지막으로 메시지를 받은 채팅방 순서대로(내림차순) 정렬되게 함
- 채팅방 생성 코드가 ServiceApplyService와 MateService에 둘다 존재해서 채팅방 중복생성되던 건 해결함 (MateService내 채팅방생성 코드 삭제함)