### PR TITLE
fix: 메이트 및 관리자 페이지에 profileimage 반환 추가

### DIFF
--- a/src/main/java/com/github/backend/service/MasterService.java
+++ b/src/main/java/com/github/backend/service/MasterService.java
@@ -6,6 +6,7 @@ import com.github.backend.repository.AuthRepository;
 import com.github.backend.repository.MateRepository;
 import com.github.backend.repository.RolesRepository;
 import com.github.backend.service.exception.CommonException;
+import com.github.backend.service.mapper.MateCaringMapper;
 import com.github.backend.service.mapper.MateMapper;
 import com.github.backend.service.mapper.UserMapper;
 import com.github.backend.web.dto.CommonResponseDto;
@@ -14,16 +15,20 @@ import com.github.backend.web.dto.master.UserDetailDto;
 import com.github.backend.web.dto.master.UserListDto;
 import com.github.backend.web.dto.master.MateDetailDto;
 import com.github.backend.web.dto.master.MateDto;
+import com.github.backend.web.dto.mates.CaringDto;
 import com.github.backend.web.entity.MateEntity;
+import com.github.backend.web.entity.ProfileImageEntity;
 import com.github.backend.web.entity.RolesEntity;
 import com.github.backend.web.entity.UserEntity;
 import com.github.backend.web.entity.enums.ErrorCode;
 import com.github.backend.web.entity.enums.MateStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.User;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -63,13 +68,36 @@ public class MasterService {
 
     public List<MateDto> findAllMateList() {
         List<MateEntity> mateList = mateRepository.findAll();
-        return mateList.stream().map(MateMapper.INSTANCE::MateEntityToDTO).toList();
+        List<ProfileImageEntity> mateImageList = mateList.stream().map(mateEntity -> mateEntity.getProfileImage())
+                .map(profileImage -> Optional.ofNullable(profileImage).orElse(null)).toList();
+        // 도움을 신청한 유저에 해당하는 이미지 하나씩 불러와서 하나씩 넣어주기
+        List<MateDto> mateListDtos = mateList.stream().map(MateMapper.INSTANCE::MateEntityToDTO).toList();
+        for (int i = 0; i < mateListDtos.size(); i++) {
+            ProfileImageEntity profileImage = mateImageList.get(i);
+            if (profileImage != null) {
+                mateListDtos.get(i).setImageName(mateImageList.get(i).getFileExt());
+                mateListDtos.get(i).setImageAddress(mateImageList.get(i).getFileUrl());
+            } else {
+                mateListDtos.get(i).setImageName("default");
+                mateListDtos.get(i).setImageAddress(null);
+            }
+        }
+
+     return mateListDtos;
     }
 
     public MateDetailDto findMate(Long mateCid) {
         MateEntity mate = mateRepository.findById(mateCid).orElseThrow(()->new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
 
         String decryptNum = maskRegistrationNumber(aesUtil.decrypt(mate.getRegistrationNum()));
+        ProfileImageEntity profileImage =mate.getProfileImage();
+        String imageAddress = null;
+        String imageName = "Default";
+
+        if (profileImage != null) {
+            imageAddress = profileImage.getFileUrl();
+            imageName = profileImage.getFileExt();
+        }
 
         return MateDetailDto.builder()
                 .mateId(mate.getMateId())
@@ -79,6 +107,8 @@ public class MasterService {
                 .mateGender(mate.getGender())
                 .mateName(mate.getName())
                 .mateStatus(mate.getMateStatus())
+                .imageAddress(imageAddress)
+                .imageName(imageName)
                 .build();
     }
 
@@ -94,7 +124,22 @@ public class MasterService {
     public List<UserListDto> findAllUserList() {
         RolesEntity roles = rolesRepository.findByRolesName("ROLE_USER");
         List<UserEntity> userList = authRepository.findAllByRoles(roles);
-        return userList.stream().map(UserMapper.INSTANCE::userEntityToDTO).toList();
+        List<ProfileImageEntity> userImageList = userList.stream().map(userEntity -> userEntity.getProfileImage())
+                .map(profileImage -> Optional.ofNullable(profileImage).orElse(null)).toList();
+        // 도움을 신청한 유저에 해당하는 이미지 하나씩 불러와서 하나씩 넣어주기
+        List<UserListDto> userListDtos = userList.stream().map(UserMapper.INSTANCE::userEntityToDTO).toList();
+        for (int i = 0; i < userListDtos.size(); i++) {
+            ProfileImageEntity profileImage = userImageList.get(i);
+            if (profileImage != null) {
+                userListDtos.get(i).setImageName(userImageList.get(i).getFileExt());
+                userListDtos.get(i).setImageAddress(userImageList.get(i).getFileUrl());
+            } else {
+                userListDtos.get(i).setImageName("default");
+                userListDtos.get(i).setImageAddress(null);
+            }
+        }
+
+        return userListDtos;
     }
 
     public CommonResponseDto blacklistingUser(boolean isBlacklisted,Long userCid) {
@@ -108,13 +153,24 @@ public class MasterService {
 
     public UserDetailDto findUser(Long userCid) {
         UserEntity user = authRepository.findById(userCid).orElseThrow(()-> new CommonException("해당 사용자를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
+        ProfileImageEntity profileImage =user.getProfileImage();
+        String imageAddress = null;
+        String imageName = "Default";
+
+        if (profileImage != null) {
+            imageAddress = profileImage.getFileUrl();
+            imageName = profileImage.getFileExt();
+        }
+
+
         return UserDetailDto.builder()
                 .userId(user.getUserId())
                 .userGender(user.getGender())
                 .userName(user.getName())
                 .phone(user.getPhoneNumber())
-                .email(user.getEmail()).build();
-
+                .email(user.getEmail())
+                .imageAddress(imageAddress)
+                .imageName(imageName).build();
     }
 
     /*-------------------------------함수 추가-----------------------------------*/

--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -250,9 +250,19 @@ public class MateService {
         double mateRating = mateRatingOptional.map(mateRatingEntity ->
                         mateRatingEntity.getTotalRating() / (double) mateRatingEntity.getRatingCount())
                 .orElse(0.0); //
+        ProfileImageEntity profileImage =mate.getProfileImage();
+        String imageAddress = null;
+        String imageName = "Default";
+
+        if (profileImage != null) {
+            imageAddress = profileImage.getFileUrl();
+            imageName = profileImage.getFileExt();
+        }
+
         return MyPageDto.builder().waitingCount(waitingCount).
                 inProgressCount(inProgressCount).finishCount(finishCount)
-                .cancelCount(cancelCount).mateRating(mateRating).build();
+                .cancelCount(cancelCount).mateRating(mateRating)
+                .imageAddress(imageAddress).imageName(imageName).build();
     }
 
     @Transactional

--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -107,33 +107,57 @@ public class MateService {
 
     @Transactional
     public List<CaringDto> viewApplyList(String careStatus,CustomMateDetails customMateDetails) {
-        MateEntity mate = mateRepository.findById(customMateDetails.getMate().getMateCid()).orElseThrow(()->new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
+        MateEntity mate = mateRepository.findById(customMateDetails.getMate().getMateCid()).orElseThrow(() -> new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         MateCareStatus mateCareStatus;
-            if (careStatus.equalsIgnoreCase("IN_PROGRESS")) {
-                mateCareStatus = MateCareStatus.IN_PROGRESS;
-            } else if (careStatus.equalsIgnoreCase("HELP_DONE")){
+        if (careStatus.equalsIgnoreCase("IN_PROGRESS")) {
+            mateCareStatus = MateCareStatus.IN_PROGRESS;
+        } else if (careStatus.equalsIgnoreCase("HELP_DONE")) {
             mateCareStatus = MateCareStatus.HELP_DONE;
-            }
-            else if(careStatus.equalsIgnoreCase("cancel")) {
+        } else if (careStatus.equalsIgnoreCase("cancel")) {
             mateCareStatus = MateCareStatus.CANCEL;
-            }
-            else {
+        } else {
             throw new InvalidValueException("상태를 잘못입력하였습니다. 다시 입력해주세요.");
-            }
+        }
         List<MateCareHistoryEntity> mateCareHistoryList = mateCareHistoryRepository.findAllByMateAndMateCareStatus(mate, mateCareStatus);
         List<CareEntity> careList = mateCareHistoryList.stream().map(MateCareHistoryEntity::getCare).toList();
-            return careList.stream().map(MateCaringMapper.INSTANCE::CareEntityToDTO).toList();
-
+        List<ProfileImageEntity> userImageList = careList.stream().map(careEntity -> careEntity.getUser().getProfileImage())
+                .map(profileImage -> Optional.ofNullable(profileImage).orElse(null)).toList();
+        // 도움을 신청한 유저에 해당하는 이미지 하나씩 불러와서 하나씩 넣어주기
+        List<CaringDto> caringDto = careList.stream().map(MateCaringMapper.INSTANCE::CareEntityToDTO).toList();
+        for (int i = 0; i < caringDto.size(); i++) {
+            ProfileImageEntity profileImage = userImageList.get(i);
+            if (profileImage != null) {
+                caringDto.get(i).setImagename(userImageList.get(i).getFileExt());
+                caringDto.get(i).setImageAddress(userImageList.get(i).getFileUrl());
+            } else {
+                caringDto.get(i).setImagename("default");
+                caringDto.get(i).setImageAddress(null);
+            }
         }
+        return caringDto;
+    }
 
 
 
     // 신규요청 내역 조회하기(대기중인 도움들 전체 조회)
     public List<CaringDto> viewAllApplyList() {
         List<CareEntity> careList = careRepository.findAllByCareStatus(CareStatus.WAITING);
-        return careList.stream().map(MateCaringMapper.INSTANCE::CareEntityToDTO).toList();
+        List<ProfileImageEntity> userImageList = careList.stream().map(careEntity -> careEntity.getUser().getProfileImage())
+                .map(profileImage -> Optional.ofNullable(profileImage).orElse(null)).toList();
+        // 도움을 신청한 유저에 해당하는 이미지 하나씩 불러와서 하나씩 넣어주기
+        List<CaringDto> caringDto = careList.stream().map(MateCaringMapper.INSTANCE::CareEntityToDTO).toList();
+        for (int i = 0; i < caringDto.size(); i++) {
+            ProfileImageEntity profileImage = userImageList.get(i);
+            if (profileImage != null) {
+                caringDto.get(i).setImagename(userImageList.get(i).getFileExt());
+                caringDto.get(i).setImageAddress(userImageList.get(i).getFileUrl());
+            } else {
+                caringDto.get(i).setImagename("default");
+                caringDto.get(i).setImageAddress(null);
+            }
+        }
+        return caringDto;
     }
-
     @Transactional
     public CommonResponseDto updateInfo(RequestUpdateDto requestUpdateDto, MultipartFile profileImages) {
 
@@ -192,11 +216,30 @@ public class MateService {
     @Transactional
     public CaringDetailsDto viewCareDetail(Long careCid) {
         CareEntity care = careRepository.findById(careCid).orElseThrow(()->new CommonException("요청하신 도움신청건을 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
-        return CaringDetailsDto.builder().date(care.getCareDate()).startTime(care.getCareDateTime())
-                .finishTime(care.getRequiredTime()).arrivalLoc(care.getArrivalLoc())
-                .gender(care.getGender()).cost(care.getCost()).careCid(careCid)
-                .content(care.getContent()).userId(care.getUser().getUserId()).build();
+        ProfileImageEntity profileImage = care.getUser().getProfileImage();
+        String imageAddress = null;
+        String imageName = "Default";
+
+        if (profileImage != null) {
+            imageAddress = profileImage.getFileUrl();
+            imageName = profileImage.getFileExt();
+        }
+
+        return CaringDetailsDto.builder()
+                .date(care.getCareDate())
+                .startTime(care.getCareDateTime())
+                .finishTime(care.getRequiredTime())
+                .arrivalLoc(care.getArrivalLoc())
+                .gender(care.getGender())
+                .cost(care.getCost())
+                .careCid(careCid)
+                .content(care.getContent())
+                .userId(care.getUser().getUserId())
+                .imageAddress(imageAddress)
+                .imageName(imageName)
+                .build();
     }
+
 
     @Transactional
     public MainPageDto countWaitingCare() {

--- a/src/main/java/com/github/backend/web/dto/master/MateDetailDto.java
+++ b/src/main/java/com/github/backend/web/dto/master/MateDetailDto.java
@@ -24,4 +24,8 @@ public class MateDetailDto {
     private String registrationNum;
     @Schema(description = "메이트 인증상태",example = "PREPARING")
     private MateStatus mateStatus;
+    @Schema(description = "메이트 프로필 사진 이름",example = "피카츄.png")
+    private String imageName;
+    @Schema(description = "메이트 프로필 사진 주소",example = "http://ddd.com")
+    private String imageAddress;
 }

--- a/src/main/java/com/github/backend/web/dto/master/MateDto.java
+++ b/src/main/java/com/github/backend/web/dto/master/MateDto.java
@@ -21,4 +21,9 @@ public class MateDto {
     private String mateName;
     @Schema(description = "블랙리스트 여부",example = "true")
     private boolean isBlacklisted;
+    @Schema(description = "메이트 프로필 사진 이름",example = "피카츄.png")
+    private String imageName;
+    @Schema(description = "메이트 프로필 사진 주소",example = "http://ddd.com")
+    private String imageAddress;
+
 }

--- a/src/main/java/com/github/backend/web/dto/master/UserDetailDto.java
+++ b/src/main/java/com/github/backend/web/dto/master/UserDetailDto.java
@@ -20,4 +20,8 @@ public class UserDetailDto {
     private String email;
     @Schema(description = "사용자 성별",example = "MEN/WOMEN")
     private Gender userGender;
+    @Schema(description = "사용자 프로필 사진 이름",example = "피카츄.png")
+    private String imageName;
+    @Schema(description = "사용자 프로필 사진 주소",example = "http://ddd.com")
+    private String imageAddress;
 }

--- a/src/main/java/com/github/backend/web/dto/master/UserListDto.java
+++ b/src/main/java/com/github/backend/web/dto/master/UserListDto.java
@@ -21,4 +21,8 @@ public class UserListDto {
     private Gender userGender;
     @Schema(description = "블랙리스트 여부",example = "true")
     private boolean isBlacklisted;
+    @Schema(description = "사용자 프로필 사진 이름",example = "피카츄.png")
+    private String imageName;
+    @Schema(description = "사용자 프로필 사진 주소",example = "http://ddd.com")
+    private String imageAddress;
 }

--- a/src/main/java/com/github/backend/web/dto/mates/CaringDetailsDto.java
+++ b/src/main/java/com/github/backend/web/dto/mates/CaringDetailsDto.java
@@ -33,4 +33,8 @@ private Long cost;
 private String content;
 @Schema(description = "희망성별",example = "MEN/WOMEN")
 private Gender gender;
+@Schema(description = "유저의 프로필 사진 이름",example="피카츄.png")
+private String imageName;
+@Schema(description = "유저 프로필사진 주소",example = "https://qewr.com")
+private String imageAddress;
 }

--- a/src/main/java/com/github/backend/web/dto/mates/CaringDto.java
+++ b/src/main/java/com/github/backend/web/dto/mates/CaringDto.java
@@ -24,4 +24,8 @@ public class CaringDto {
     private LocalTime finishTime;
     @Schema(description = "목적지",example = "00병원")
     private String arrivalLoc;
+    @Schema(description = "유저의 프로필 사진 이름",example="피카츄.png")
+    private String imagename;
+    @Schema(description = "유저 프로필사진 주소",example = "https://qewr.com")
+    private String imageAddress;
 }

--- a/src/main/java/com/github/backend/web/dto/mates/MyPageDto.java
+++ b/src/main/java/com/github/backend/web/dto/mates/MyPageDto.java
@@ -21,4 +21,8 @@ public class MyPageDto {
     private int cancelCount;
     @Schema(description = "메이트 별점",example = "4.5")
     private double mateRating;
+    @Schema(description = "메이트 프로필 사진 이름",example = "피카츄.png")
+    private String imageName;
+    @Schema(description = "메이트 프로필 사진 주소",example = "http://ddd.com")
+    private String imageAddress;
 }


### PR DESCRIPTION
- 메이트의 도움내역 조회 페이지에서 해당 도움을 신청한 사용자의 프로필이미지를 볼 수 있도록 return dto (caringDto 및 caringDetailDto)에 이미지 이름과 주소 추가