### PR TITLE
fix: transactional 어노테이션 추가 및 mateCareHistory 검색조건 수정

### DIFF
--- a/src/main/java/com/github/backend/repository/MateCareHistoryRepository.java
+++ b/src/main/java/com/github/backend/repository/MateCareHistoryRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface MateCareHistoryRepository extends JpaRepository<MateCareHistoryEntity,Long> {
-    MateCareHistoryEntity findByCareAndMate(CareEntity care, MateEntity mate);
+    MateCareHistoryEntity findByCareAndMateAndMateCareStatus(CareEntity care, MateEntity mate, MateCareStatus mateCareStatus);
 
     int countByMateCareStatusAndMate(MateCareStatus mateCareStatus,MateEntity mate);
 

--- a/src/main/java/com/github/backend/service/MasterService.java
+++ b/src/main/java/com/github/backend/service/MasterService.java
@@ -22,6 +22,8 @@ import com.github.backend.web.entity.RolesEntity;
 import com.github.backend.web.entity.UserEntity;
 import com.github.backend.web.entity.enums.ErrorCode;
 import com.github.backend.web.entity.enums.MateStatus;
+import jakarta.transaction.TransactionScoped;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.User;
@@ -41,7 +43,7 @@ public class MasterService {
     private final RolesRepository rolesRepository;
     private final AESUtil aesUtil;
 
-    // 메이트 부분
+    @Transactional
     public CommonResponseDto approveMate(Long mateCid) {
         MateEntity mate = mateRepository.findById(mateCid).orElseThrow(()->new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         mate.setMateStatus(MateStatus.COMPLETE);
@@ -52,7 +54,7 @@ public class MasterService {
         return CommonResponseDto.builder().code(200).success(true).message("해당 메이트 인증요청을 승인했습니다.").build();
     }
 
-
+    @Transactional
     public CommonResponseDto unapprovedMate(Long mateCid, UnapprovedMateDto unapprovedMateDto) {
         MateEntity mate = mateRepository.findById(mateCid).orElseThrow(()->new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         mate.setMateStatus(MateStatus.FAILED);
@@ -64,8 +66,7 @@ public class MasterService {
         return CommonResponseDto.builder().code(200).success(true).message("해당 메이트 인증요청을 미승인했습니다.").build();
     }
 
-
-
+    @Transactional
     public List<MateDto> findAllMateList() {
         List<MateEntity> mateList = mateRepository.findAll();
         List<ProfileImageEntity> mateImageList = mateList.stream().map(mateEntity -> mateEntity.getProfileImage())
@@ -86,6 +87,7 @@ public class MasterService {
      return mateListDtos;
     }
 
+    @Transactional
     public MateDetailDto findMate(Long mateCid) {
         MateEntity mate = mateRepository.findById(mateCid).orElseThrow(()->new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
 
@@ -112,6 +114,7 @@ public class MasterService {
                 .build();
     }
 
+    @Transactional
     public CommonResponseDto blacklistingMate(boolean isBlacklisted, Long mateCid) {
             MateEntity mate = mateRepository.findById(mateCid).orElseThrow(()->new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
             mate.setBlacklisted(isBlacklisted);
@@ -119,8 +122,10 @@ public class MasterService {
         return CommonResponseDto.builder().code(200).success(true).message("블랙리스트 요청이 성공적으로 처리됐습니다.").build();
     }
 
-
-    // 사용자 부분
+    /**
+     * 밑에부터 사용자 관련 코드
+     */
+    @Transactional
     public List<UserListDto> findAllUserList() {
         RolesEntity roles = rolesRepository.findByRolesName("ROLE_USER");
         List<UserEntity> userList = authRepository.findAllByRoles(roles);
@@ -141,7 +146,7 @@ public class MasterService {
 
         return userListDtos;
     }
-
+    @Transactional
     public CommonResponseDto blacklistingUser(boolean isBlacklisted,Long userCid) {
             UserEntity user = authRepository.findById(userCid).orElseThrow(()->new CommonException("해당 사용자를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
             user.setBlacklisted(isBlacklisted);
@@ -150,7 +155,7 @@ public class MasterService {
         return CommonResponseDto.builder().code(200).success(true).message("블랙리스트 요청이 성공적으로 처리됐습니다.").build();
     }
 
-
+    @Transactional
     public UserDetailDto findUser(Long userCid) {
         UserEntity user = authRepository.findById(userCid).orElseThrow(()-> new CommonException("해당 사용자를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         ProfileImageEntity profileImage =user.getProfileImage();

--- a/src/main/java/com/github/backend/service/MasterService.java
+++ b/src/main/java/com/github/backend/service/MasterService.java
@@ -22,8 +22,6 @@ import com.github.backend.web.entity.RolesEntity;
 import com.github.backend.web.entity.UserEntity;
 import com.github.backend.web.entity.enums.ErrorCode;
 import com.github.backend.web.entity.enums.MateStatus;
-import jakarta.transaction.TransactionScoped;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.User;
@@ -45,7 +43,6 @@ public class MasterService {
     private final RolesRepository rolesRepository;
     private final AESUtil aesUtil;
 
-    @Transactional
     public CommonResponseDto approveMate(Long mateCid) {
         MateEntity mate = mateRepository.findById(mateCid).orElseThrow(()->new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         mate.setMateStatus(MateStatus.COMPLETE);
@@ -56,7 +53,6 @@ public class MasterService {
         return CommonResponseDto.builder().code(200).success(true).message("해당 메이트 인증요청을 승인했습니다.").build();
     }
 
-    @Transactional
     public CommonResponseDto unapprovedMate(Long mateCid, UnapprovedMateDto unapprovedMateDto) {
         MateEntity mate = mateRepository.findById(mateCid).orElseThrow(()->new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         mate.setMateStatus(MateStatus.FAILED);
@@ -68,7 +64,7 @@ public class MasterService {
         return CommonResponseDto.builder().code(200).success(true).message("해당 메이트 인증요청을 미승인했습니다.").build();
     }
 
-    @Transactional
+
     public List<MateDto> findAllMateList() {
         List<MateEntity> mateList = mateRepository.findAll();
         List<ProfileImageEntity> mateImageList = mateList.stream().map(mateEntity -> mateEntity.getProfileImage())
@@ -89,7 +85,7 @@ public class MasterService {
      return mateListDtos;
     }
 
-    @Transactional
+
     public MateDetailDto findMate(Long mateCid) {
         MateEntity mate = mateRepository.findById(mateCid).orElseThrow(()->new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
 
@@ -116,7 +112,7 @@ public class MasterService {
                 .build();
     }
 
-    @Transactional
+
     public CommonResponseDto blacklistingMate(boolean isBlacklisted, Long mateCid) {
             MateEntity mate = mateRepository.findById(mateCid).orElseThrow(()->new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
             mate.setBlacklisted(isBlacklisted);
@@ -127,7 +123,7 @@ public class MasterService {
     /**
      * 밑에부터 사용자 관련 코드
      */
-    @Transactional
+
     public List<UserListDto> findAllUserList() {
         RolesEntity roles = rolesRepository.findByRolesName("ROLE_USER");
         List<UserEntity> userList = authRepository.findAllByRoles(roles);
@@ -148,7 +144,7 @@ public class MasterService {
 
         return userListDtos;
     }
-    @Transactional
+
     public CommonResponseDto blacklistingUser(boolean isBlacklisted,Long userCid) {
             UserEntity user = authRepository.findById(userCid).orElseThrow(()->new CommonException("해당 사용자를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
             user.setBlacklisted(isBlacklisted);
@@ -157,7 +153,7 @@ public class MasterService {
         return CommonResponseDto.builder().code(200).success(true).message("블랙리스트 요청이 성공적으로 처리됐습니다.").build();
     }
 
-    @Transactional
+
     public UserDetailDto findUser(Long userCid) {
         UserEntity user = authRepository.findById(userCid).orElseThrow(()-> new CommonException("해당 사용자를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         ProfileImageEntity profileImage =user.getProfileImage();

--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 public class MateService {
 
     private final PasswordEncoder passwordEncoder;
@@ -35,12 +36,11 @@ public class MateService {
     private final MateRepository mateRepository;
     private final MateCareHistoryRepository mateCareHistoryRepository;
     private final RatingRepository ratingRepository;
-    private final ChatRoomRepository chatRoomRepository;
     private final AuthRepository authRepository;
     private final ImageUploadService imageUploadService;
     private final ProfileImageRepository profileImageRepository;
 
-    @Transactional
+
     public CommonResponseDto applyCaring(Long careId, CustomMateDetails customMateDetails) {
         Long mateId = customMateDetails.getMate().getMateCid();
         CareEntity care = careRepository.findById(careId).orElseThrow(()->new CommonException("요청하신 도움신청건을 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
@@ -67,7 +67,7 @@ public class MateService {
         return CommonResponseDto.builder().code(200).success(true).message("도움 지원이 완료되었습니다!").build();
     }
 
-    @Transactional
+
     public CommonResponseDto finishCaring(Long careCid, CustomMateDetails customMateDetails) {
         CareEntity care = careRepository.findById(careCid).orElseThrow(()->new CommonException("요청하신 도움을 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         care.setCareStatus(CareStatus.HELP_DONE);
@@ -78,7 +78,7 @@ public class MateService {
         return CommonResponseDto.builder().code(200).success(true).message("도움이 완료되었습니다!").build();
     }
 
-    @Transactional
+
     public CommonResponseDto cancelCaring(Long careCid, CustomMateDetails customMateDetails) {
         CareEntity care = careRepository.findById(careCid).orElseThrow(()->new CommonException("요청하신 도움을 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         care.setCareStatus(CareStatus.WAITING);
@@ -96,9 +96,7 @@ public class MateService {
                 .message("도움을 성공적으로 취소했습니다!").build();
     }
 
-    ;
 
-    @Transactional
     public List<CaringDto> viewApplyList(String careStatus,CustomMateDetails customMateDetails) {
         MateEntity mate = mateRepository.findById(customMateDetails.getMate().getMateCid()).orElseThrow(() -> new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         MateCareStatus mateCareStatus;
@@ -131,7 +129,7 @@ public class MateService {
     }
 
 
-    @Transactional
+
     public List<CaringDto> viewAllApplyList() {
         List<CareEntity> careList = careRepository.findAllByCareStatus(CareStatus.WAITING);
         List<ProfileImageEntity> userImageList = careList.stream().map(careEntity -> careEntity.getUser().getProfileImage())
@@ -150,7 +148,7 @@ public class MateService {
         }
         return caringDto;
     }
-    @Transactional
+
     public CommonResponseDto updateInfo(RequestUpdateDto requestUpdateDto, MultipartFile profileImages) {
 
         if (!mateRepository.existsById(requestUpdateDto.getCid())) {
@@ -207,7 +205,7 @@ public class MateService {
                 .build();
     }
 
-    @Transactional
+
     public CaringDetailsDto viewCareDetail(Long careCid) {
         CareEntity care = careRepository.findById(careCid).orElseThrow(()->new CommonException("요청하신 도움신청건을 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         ProfileImageEntity profileImage = care.getUser().getProfileImage();
@@ -235,13 +233,12 @@ public class MateService {
     }
 
 
-    @Transactional
     public MainPageDto countWaitingCare() {
         int count = careRepository.countByCareStatus(CareStatus.WAITING);
         return new MainPageDto(count);
     }
 
-    @Transactional
+
     public MyPageDto countCareStatus(CustomMateDetails customMateDetails) {
         MateEntity mate = customMateDetails.getMate();
         int waitingCount = careRepository.countByCareStatus(CareStatus.WAITING);
@@ -267,7 +264,7 @@ public class MateService {
                 .imageAddress(imageAddress).imageName(imageName).build();
     }
 
-    @Transactional
+
     public CommonResponseDto completePayment(Long careCid, boolean isCompletedPayment) {
       CareEntity care = careRepository.findById(careCid).orElseThrow(()->new CommonException("요청하신 도움신청건을 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
       if (isCompletedPayment) {

--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -67,22 +67,23 @@ public class MateService {
         return CommonResponseDto.builder().code(200).success(true).message("도움 지원이 완료되었습니다!").build();
     }
 
+    @Transactional
     public CommonResponseDto finishCaring(Long careCid, CustomMateDetails customMateDetails) {
         CareEntity care = careRepository.findById(careCid).orElseThrow(()->new CommonException("요청하신 도움을 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         care.setCareStatus(CareStatus.HELP_DONE);
-        MateCareHistoryEntity mateCareHistory = mateCareHistoryRepository.findByCareAndMate(care, customMateDetails.getMate());
+        MateCareHistoryEntity mateCareHistory = mateCareHistoryRepository.findByCareAndMateAndMateCareStatus(care, customMateDetails.getMate(), MateCareStatus.IN_PROGRESS);
         mateCareHistory.setMateCareStatus(MateCareStatus.HELP_DONE);
         careRepository.save(care);
         mateCareHistoryRepository.save(mateCareHistory);
         return CommonResponseDto.builder().code(200).success(true).message("도움이 완료되었습니다!").build();
     }
 
-
+    @Transactional
     public CommonResponseDto cancelCaring(Long careCid, CustomMateDetails customMateDetails) {
         CareEntity care = careRepository.findById(careCid).orElseThrow(()->new CommonException("요청하신 도움을 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         care.setCareStatus(CareStatus.WAITING);
         care.setMate(null);
-        MateCareHistoryEntity mateCareHistory = mateCareHistoryRepository.findByCareAndMate(care, customMateDetails.getMate());
+        MateCareHistoryEntity mateCareHistory = mateCareHistoryRepository.findByCareAndMateAndMateCareStatus(care, customMateDetails.getMate(),MateCareStatus.IN_PROGRESS);
         mateCareHistory.setMateCareStatus(MateCareStatus.CANCEL);
         careRepository.save(care);
         mateCareHistoryRepository.save(mateCareHistory);
@@ -130,8 +131,7 @@ public class MateService {
     }
 
 
-
-    // 신규요청 내역 조회하기(대기중인 도움들 전체 조회)
+    @Transactional
     public List<CaringDto> viewAllApplyList() {
         List<CareEntity> careList = careRepository.findAllByCareStatus(CareStatus.WAITING);
         List<ProfileImageEntity> userImageList = careList.stream().map(careEntity -> careEntity.getUser().getProfileImage())


### PR DESCRIPTION
- 대기중인 도움조회시 lazyinitializationexception 발생으로 @Transactional 전체적용추가
- 메이트가 도움완료시 MateCareHistory에서 CareEntity와 MateEntity만 갖고 조회하여 가져오는경우, 취소 이력이 있지만 다시 신청한 도움의 경우 mate엔티티와 care엔티티가 중복되어 값이 2개 리턴되는 오류발생.
- 해결 위해 mateCareHistory 검색 조건에 메이트도움상태도 추가