### PR TITLE
fix: MateService의 applyCaring 수정

### DIFF
--- a/src/main/java/com/github/backend/repository/MateCareHistoryRepository.java
+++ b/src/main/java/com/github/backend/repository/MateCareHistoryRepository.java
@@ -14,4 +14,6 @@ public interface MateCareHistoryRepository extends JpaRepository<MateCareHistory
     int countByMateCareStatusAndMate(MateCareStatus mateCareStatus,MateEntity mate);
 
     List<MateCareHistoryEntity> findAllByMateAndMateCareStatus(MateEntity mate, MateCareStatus mateCareStatus);
+
+    boolean existsByCareAndMateAndMateCareStatus(CareEntity care, MateEntity mate, MateCareStatus mateCareStatus);
 }

--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -60,8 +60,16 @@ public class MateService {
 //        String phoneNum = care.getUser().getPhoneNumber();
 //        sendMessageService.sendMessage(phoneNum,messageContent);
 
-        MateCareHistoryEntity mateCareHistory = MateCareHistoryEntity.builder().mate(mate).care(care).mateCareStatus(MateCareStatus.IN_PROGRESS).build();
-        mateCareHistoryRepository.save(mateCareHistory);
+        if(mateCareHistoryRepository.existsByCareAndMateAndMateCareStatus(care,mate,MateCareStatus.CANCEL)){
+            MateCareHistoryEntity mateCareHistory = mateCareHistoryRepository.findByCareAndMateAndMateCareStatus(care,mate,MateCareStatus.CANCEL);
+            mateCareHistory.setMateCareStatus(MateCareStatus.IN_PROGRESS);
+            mateCareHistoryRepository.save(mateCareHistory);
+        }
+        else {
+            MateCareHistoryEntity mateCareHistory = MateCareHistoryEntity.builder().mate(mate).care(care).mateCareStatus(MateCareStatus.IN_PROGRESS).build();
+            mateCareHistoryRepository.save(mateCareHistory);
+        }
+
         careRepository.save(care);
 
         return CommonResponseDto.builder().code(200).success(true).message("도움 지원이 완료되었습니다!").build();


### PR DESCRIPTION
- 메이트가 도움을 취소하고, 취소한 도움을 다시 신청했을때 mateCareHistory에 해당 메이트의 도움내역이 중복되고있었음
- 메이트가 도움을 지원할때 해당 도움을 이전에 취소한 내역이 있다면, 그 도움내역의 상태를 바꾸는 방식으로 코드 변경