### PR TITLE
fix: 메이트 등록상태, 프로필 이미지 수정 후 적용

### DIFF
--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -204,13 +204,26 @@ public class MateService {
 
     public ResponseMyInfoDto findByMate(CustomMateDetails customMateDetails) {
         MateEntity mate = mateRepository.findById(customMateDetails.getMate().getMateCid()).orElseThrow(() -> new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
-        return ResponseMyInfoDto.builder()
-                .cid(mate.getMateCid())
-                .name(mate.getName())
-                .id(mate.getMateId())
-                .email(mate.getEmail())
-                .phoneNumber(mate.getPhoneNumber())
-                .build();
+
+        if(mate.getProfileImage() == null){
+            return ResponseMyInfoDto.builder()
+                    .cid(mate.getMateCid())
+                    .name(mate.getName())
+                    .id(mate.getMateId())
+                    .email(mate.getEmail())
+                    .phoneNumber(mate.getPhoneNumber())
+                    .profileImage(null)
+                    .build();
+        }else{
+            return ResponseMyInfoDto.builder()
+                    .cid(mate.getMateCid())
+                    .name(mate.getName())
+                    .id(mate.getMateId())
+                    .email(mate.getEmail())
+                    .phoneNumber(mate.getPhoneNumber())
+                    .profileImage(mate.getProfileImage().getFileUrl())
+                    .build();
+        }
     }
 
 

--- a/src/main/java/com/github/backend/service/auth/AuthService.java
+++ b/src/main/java/com/github/backend/service/auth/AuthService.java
@@ -109,13 +109,10 @@ public class AuthService {
             if(mates.isBlacklisted())
               throw new CommonException("해당 메이트는 관리자에게 문의하십시오. helpUAdmin@admin.com", ErrorCode.BAD_REQUEST_RESPONSE);
 
-            if(mates.getMateStatus().equals(MateStatus.PREPARING))
-              throw new CommonException("관리자의 허가가 필요한 아이디 입니다.", ErrorCode.BAD_REQUEST_RESPONSE);
-
             accessToken = jwtTokenProvider.createAccessToken(2, mates.getMateId());
             refreshToken = jwtTokenProvider.createRefreshToken(2, mates.getMateId());
             rolesName = mates.getRoles().getRolesName();
-
+            response.put("register_status", mates.getMateStatus().toString());
           }
 
           // Redis에 token 적용

--- a/src/main/java/com/github/backend/service/auth/UserService.java
+++ b/src/main/java/com/github/backend/service/auth/UserService.java
@@ -51,13 +51,25 @@ public class UserService implements UserDetailsService {
     public ResponseMyInfoDto findByUser(CustomUserDetails customUserDetails) {
         UserEntity user = authRepository.findById(customUserDetails.getUser().getUserCid()).orElseThrow(() -> new CommonException("userId: " + customUserDetails.getUser() + "를 데이터베이스에서 찾을 수 없습니다."));
 
-        return ResponseMyInfoDto.builder()
-                .cid(user.getUserCid())
-                .name(user.getName())
-                .id(user.getUserId())
-                .email(user.getEmail())
-                .phoneNumber(user.getPhoneNumber())
-                .build();
+        if(user.getProfileImage() == null){
+            return ResponseMyInfoDto.builder()
+                    .cid(user.getUserCid())
+                    .name(user.getName())
+                    .id(user.getUserId())
+                    .email(user.getEmail())
+                    .phoneNumber(user.getPhoneNumber())
+                    .profileImage(null)
+                    .build();
+        }else{
+            return ResponseMyInfoDto.builder()
+                    .cid(user.getUserCid())
+                    .name(user.getName())
+                    .id(user.getUserId())
+                    .email(user.getEmail())
+                    .phoneNumber(user.getPhoneNumber())
+                    .profileImage(user.getProfileImage().getFileUrl())
+                    .build();
+        }
     }
 
     @Transactional

--- a/src/main/java/com/github/backend/web/dto/users/ResponseMyInfoDto.java
+++ b/src/main/java/com/github/backend/web/dto/users/ResponseMyInfoDto.java
@@ -13,12 +13,14 @@ public class ResponseMyInfoDto {
     private String id;
     private String email;
     private String phoneNumber;
+    private String profileImage;
     @Builder
-    public ResponseMyInfoDto(Long cid,String name, String id, String email, String phoneNumber){
+    public ResponseMyInfoDto(Long cid,String name, String id, String email, String phoneNumber, String profileImage){
       this.cid = cid;
       this.name = name;
       this.id = id;
       this.email = email;
       this.phoneNumber = phoneNumber;
+      this.profileImage = profileImage;
     }
 }


### PR DESCRIPTION
- 메이트 로그인 시에 exception이 아닌 결과 상태를 json파일에 넣어서 보내줌
- 회원 수정 에서 이미지를 넣고 나서 수정이 완료되면 find에서 결과 보여주는 로직 수정