### PR TITLE
Fix mate service apply caring 선착순 문제 해결

### DIFF
--- a/src/main/java/com/github/backend/repository/ServiceApplyRepository.java
+++ b/src/main/java/com/github/backend/repository/ServiceApplyRepository.java
@@ -6,7 +6,9 @@ import com.github.backend.web.entity.UserEntity;
 import com.github.backend.web.entity.custom.CustomUserDetails;
 import com.github.backend.web.entity.enums.CareStatus;
 import com.github.backend.web.entity.enums.MateCareStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -23,11 +25,6 @@ public interface ServiceApplyRepository extends JpaRepository<CareEntity, Long >
     
     Integer countByCareStatus(CareStatus careStatus);
 
-    @Query("SELECT c.mate FROM CareEntity c " +
-          "INNER JOIN c.mate m " +
-          "WHERE m.mateCid = :mateCid")
-    Optional<CareEntity> findByMateCid(Long mateCid);
-
-
-    CareEntity findCareEntityByContent(String content);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<CareEntity> findById(Long Id);
 }

--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -44,6 +44,9 @@ public class MateService {
     public CommonResponseDto applyCaring(Long careId, CustomMateDetails customMateDetails) {
         Long mateId = customMateDetails.getMate().getMateCid();
         CareEntity care = careRepository.findById(careId).orElseThrow(()->new CommonException("요청하신 도움신청건을 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
+        if(care.getCareStatus().equals(CareStatus.IN_PROGRESS)){
+            throw new CommonException("요청하신 도움은 이미 지원완료되었습니다. 다른 도움에 지원해주세요!",ErrorCode.BAD_REQUEST_RESPONSE);
+        }
         MateEntity mate = mateRepository.findById(mateId).orElseThrow(()->new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
         // 만약 동일한 날짜 같은 시간대에 이미 신청한 도움이 있다면 신청불가능하게끔하기
         List<MateCareHistoryEntity> mateCareHistoryEntities = mateCareHistoryRepository.findAllByMateAndMateCareStatus(mate, MateCareStatus.IN_PROGRESS);

--- a/src/main/java/com/github/backend/service/MateService.java
+++ b/src/main/java/com/github/backend/service/MateService.java
@@ -105,19 +105,10 @@ public class MateService {
     }
 
 
-    public List<CaringDto> viewApplyList(String careStatus,CustomMateDetails customMateDetails) {
+    public List<CaringDto> viewApplyList(String mateCareStatus,CustomMateDetails customMateDetails) {
         MateEntity mate = mateRepository.findById(customMateDetails.getMate().getMateCid()).orElseThrow(() -> new CommonException("해당 메이트를 찾을 수 없습니다.", ErrorCode.FAIL_RESPONSE));
-        MateCareStatus mateCareStatus;
-        if (careStatus.equalsIgnoreCase("IN_PROGRESS")) {
-            mateCareStatus = MateCareStatus.IN_PROGRESS;
-        } else if (careStatus.equalsIgnoreCase("HELP_DONE")) {
-            mateCareStatus = MateCareStatus.HELP_DONE;
-        } else if (careStatus.equalsIgnoreCase("cancel")) {
-            mateCareStatus = MateCareStatus.CANCEL;
-        } else {
-            throw new InvalidValueException("상태를 잘못입력하였습니다. 다시 입력해주세요.");
-        }
-        List<MateCareHistoryEntity> mateCareHistoryList = mateCareHistoryRepository.findAllByMateAndMateCareStatus(mate, mateCareStatus);
+        MateCareStatus status = MateCareStatus.valueOfTerm(mateCareStatus.toUpperCase());
+        List<MateCareHistoryEntity> mateCareHistoryList = mateCareHistoryRepository.findAllByMateAndMateCareStatus(mate, status);
         List<CareEntity> careList = mateCareHistoryList.stream().map(MateCareHistoryEntity::getCare).toList();
         List<ProfileImageEntity> userImageList = careList.stream().map(careEntity -> careEntity.getUser().getProfileImage())
                 .map(profileImage -> Optional.ofNullable(profileImage).orElse(null)).toList();

--- a/src/main/java/com/github/backend/web/entity/enums/MateCareStatus.java
+++ b/src/main/java/com/github/backend/web/entity/enums/MateCareStatus.java
@@ -1,13 +1,26 @@
 package com.github.backend.web.entity.enums;
 
+import com.github.backend.service.exception.CommonException;
+
 public enum MateCareStatus {
-    IN_PROGRESS("진행 중"),
-    HELP_DONE("도움 완료"),
-    CANCEL("취소");
+    IN_PROGRESS("IN_PROGRESS","진행 중"),
+    HELP_DONE("HELP_DONE","도움 완료"),
+    CANCEL("CANCEL","취소");
 
-    private final String mateCareStatus;
+    private final String mateCareStatus_english;
+    private final String mateCareStatus_korean;
 
-    MateCareStatus(String mateCareStatus) {
-        this.mateCareStatus = mateCareStatus;
+    MateCareStatus(String mateCareStatus_english, String mateCareStatus_korean) {
+        this.mateCareStatus_english = mateCareStatus_english;
+        this.mateCareStatus_korean = mateCareStatus_korean;
+    }
+
+    public static MateCareStatus valueOfTerm(String mateCareStatus) {
+        for(MateCareStatus status: values()){
+            if(mateCareStatus.equals(status.mateCareStatus_english)){
+                return status;
+            }
+        }
+        throw new CommonException("존재하지 않는 상태입니다. 다시 입력해주세요",ErrorCode.BAD_REQUEST_RESPONSE);
     }
 }


### PR DESCRIPTION
- 순차적으로 동일한 careCid로 도움을 지원했을 경우 CareStatus에 대한 고려없이 모두 다 지원가능하도록 했던 문제 수정
*(*선착순 1명만 지원가능하도록 해야했는데, 순차적으로 동일한 careCid에 지원했을때 마지막으로 지원한 mate가 care엔티티에 저장되는 문제가 있었음)**
- 동시에 동일한 careCid를 지원했을때, 1명만 지원되도록 하기위해 lock을 설정.